### PR TITLE
add compact flag to service

### DIFF
--- a/src/main/java/de/starwit/sbom/generator/DocumentDesignConfig.java
+++ b/src/main/java/de/starwit/sbom/generator/DocumentDesignConfig.java
@@ -4,7 +4,14 @@ public class DocumentDesignConfig {
     String title;
     String logoPath;
     int baseFontSize;
+    boolean compact = false;
 
+    public boolean isCompact() {
+        return compact;
+    }
+    public void setCompact(boolean compact) {
+        this.compact = compact;
+    }
     public String getTitle() {
         return title;
     }

--- a/src/main/java/de/starwit/sbom/generator/ReportGenerator.java
+++ b/src/main/java/de/starwit/sbom/generator/ReportGenerator.java
@@ -47,7 +47,7 @@ public class ReportGenerator {
                 addHeader(document, dc.getTitle());
                 document.add(addMetadata(bom, document, baseFont)); 
                 document.newPage();
-                document.add(buildComponentTable(bom, document, baseFont));
+                document.add(buildComponentTable(bom, document, baseFont, dc.isCompact()));
                 document.newPage();
             }
             document.close();
@@ -67,7 +67,7 @@ public class ReportGenerator {
             addHeader(document, dc.getTitle());
             document.add(addMetadata(bom, document, baseFont)); 
             document.newPage();
-            document.add(buildComponentTable(bom, document, baseFont));
+            document.add(buildComponentTable(bom, document, baseFont, dc.isCompact()));
             document.close();
         } catch (DocumentException e) {
             log.info("Can't write document " + e.getMessage());
@@ -122,11 +122,16 @@ public class ReportGenerator {
         return table;
     }
 
-    private PdfPTable buildComponentTable(Bom bom, Document document, Font font) {
+    private PdfPTable buildComponentTable(Bom bom, Document document, Font font, boolean isCompact) {
         float width = document.getPageSize().getWidth();
         document.open();
 
-        PdfPTable table = new PdfPTable(6);
+        PdfPTable table;
+        if(isCompact) {
+            table = new PdfPTable(5);
+        } else {
+            table = new PdfPTable(6);
+        }
         table.getDefaultCell().setBorder(1);
         table.setHorizontalAlignment(0);
         table.setTotalWidth(width - 72);
@@ -141,7 +146,9 @@ public class ReportGenerator {
         table.addCell(new Phrase("Version", font));
         table.addCell(new Phrase("License", font));
         table.addCell(new Phrase("Type", font));
-        table.addCell(new Phrase("Description", font));
+        if(!isCompact) {
+            table.addCell(new Phrase("Description", font));
+        }
 
         for (Component c : bom.getComponents()) {
             table.addCell(new Phrase(c.getName(), font));
@@ -185,11 +192,13 @@ public class ReportGenerator {
             } else {
                 table.addCell(new Phrase("", font));
             }
-
-            if(c.getDescription() != null) {
-                table.addCell(new Phrase(c.getDescription(), FontFactory.getFont(FontFactory.HELVETICA, font.getSize()-2)));
-            } else {
-                table.addCell(new Phrase("", font));
+            
+            if(!isCompact) {
+                if(c.getDescription() != null) {
+                    table.addCell(new Phrase(c.getDescription(), FontFactory.getFont(FontFactory.HELVETICA, font.getSize()-2)));
+                } else {
+                    table.addCell(new Phrase("", font));
+                }
             }
             
         }

--- a/src/main/java/de/starwit/sbom/rest/ReportController.java
+++ b/src/main/java/de/starwit/sbom/rest/ReportController.java
@@ -38,8 +38,12 @@ public class ReportController {
     private RestTemplate restTemplate;    
     
     @Operation(summary = "Generate PDF report based on provided CycloneDX definition")
-    @PostMapping("/{dcId}")
-    public void getReport(HttpServletResponse response, @RequestBody String json, @PathVariable("dcId") int dcId) {
+    @PostMapping("/{dcId}/{compact}")
+    public void getReport(HttpServletResponse response, @RequestBody String json, @PathVariable("dcId") int dcId, @PathVariable("compact") boolean compact) {
+        ReportRequestDTO dto = new ReportRequestDTO();
+        dto.setCompact(compact);
+        dto.setDcId(dcId);
+        dto.setSbom(json);
         response.setContentType("application/pdf");
         DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd:hh:mm:ss");
         String currentDateTime = dateFormatter.format(new Date());
@@ -51,7 +55,7 @@ public class ReportController {
         ServletOutputStream out;
         try {
             out = response.getOutputStream();
-            dgs.generateReport(json, dcId, out);
+            dgs.generateReport(dto, out);
         } catch (IOException e) {
             log.error("Can't create output stream for pdf");
             //TODO send 500 response code
@@ -64,6 +68,7 @@ public class ReportController {
 
         String json = loadCycloneDXData(reportData.getSbomURI());
         if(!json.equals("")) {
+            reportData.setSbom(json);
             response.setContentType("application/pdf");
             DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd:hh:mm:ss");
             String currentDateTime = dateFormatter.format(new Date());
@@ -74,7 +79,7 @@ public class ReportController {
             ServletOutputStream out;
             try {
                 out = response.getOutputStream();
-                dgs.generateReport(json, reportData.getDcId(), out);
+                dgs.generateReport(reportData, out);
             } catch (IOException e) {
                 log.error("Can't create output stream for pdf");
                 response.setStatus(500);

--- a/src/main/java/de/starwit/sbom/rest/ReportRequestDTO.java
+++ b/src/main/java/de/starwit/sbom/rest/ReportRequestDTO.java
@@ -3,17 +3,38 @@ package de.starwit.sbom.rest;
 public class ReportRequestDTO {
     private String sbomURI;
     private int dcId;
-    
+    private boolean compact;
+    private String sbom;
+
     public String getSbomURI() {
         return sbomURI;
     }
+
+    public String getSbom() {
+        return sbom;
+    }
+
+    public void setSbom(String sbom) {
+        this.sbom = sbom;
+    }
+
     public void setSbomURI(String sbomURI) {
         this.sbomURI = sbomURI;
     }
+
     public int getDcId() {
         return dcId;
     }
+
     public void setDcId(int dcId) {
         this.dcId = dcId;
+    }
+
+    public boolean isCompact() {
+        return compact;
+    }
+
+    public void setCompact(boolean compact) {
+        this.compact = compact;
     }
 }

--- a/src/main/java/de/starwit/sbom/service/DocumentGeneratorService.java
+++ b/src/main/java/de/starwit/sbom/service/DocumentGeneratorService.java
@@ -1,10 +1,6 @@
 package de.starwit.sbom.service;
 
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.cyclonedx.model.Bom;
 import org.slf4j.Logger;
@@ -14,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import de.starwit.sbom.generator.DocumentDesignConfig;
 import de.starwit.sbom.generator.ReportGenerator;
+import de.starwit.sbom.rest.ReportRequestDTO;
 
 @Service
 public class DocumentGeneratorService {
@@ -28,34 +25,11 @@ public class DocumentGeneratorService {
     @Autowired
     DocumentDesignConfigService configService;
 
-    public void generateReport(String bomJson, int dcId, OutputStream out) {
-        Bom bom = jsonParser.parseJsonToBOM(bomJson);
-        reportGenerator.renderPDF(bom, configService.getDocumentDesignConfig(dcId), out);
+    public void generateReport(ReportRequestDTO dto, OutputStream out) {
+        Bom bom = jsonParser.parseJsonToBOM(dto.getSbom());
+        DocumentDesignConfig dc = configService.getDocumentDesignConfig(dto.getDcId());
+        dc.setCompact(dto.isCompact());
+        reportGenerator.renderPDF(bom, dc, out);        
     }
-
-    public static void main(String[] args) {
-
-        // TODO -> unit tests
-        JSONParser jsonParser = new JSONParser();
-        ReportGenerator reportGenerator = new ReportGenerator();
-
-        String jsonFilePathBackend = "src/test/java/de/starwit/sbom/sbom-backend.json";
-        String jsonFilePathFrontend = "src/test/java/de/starwit/sbom/sbom-frontend.json";
-        String reportFilename = "report.pdf";
-
-        DocumentDesignConfig dc =  new DocumentDesignConfig();
-        dc.setBaseFontSize(10);
-        dc.setTitle("Starwit's AI Cockpit");
-        dc.setLogoPath("starwit.png");     
-
-        List<Bom> boms = new ArrayList<>();
-        boms.add(jsonParser.fileBasedParser(jsonFilePathBackend));
-        boms.add(jsonParser.fileBasedParser(jsonFilePathFrontend));
-
-        try {
-            reportGenerator.renderPDF(boms, dc, new FileOutputStream(reportFilename));
-        } catch (FileNotFoundException e) {
-            log.error("Can't create PDF " + e.getMessage());
-        }        
-    }    
+    
 }

--- a/src/test/java/de/starwit/sbom/SBomGeneratorApplicationTests.java
+++ b/src/test/java/de/starwit/sbom/SBomGeneratorApplicationTests.java
@@ -26,7 +26,8 @@ class SBomGeneratorApplicationTests {
 	}
 
     @Test
-    public void parseODPResult() throws Exception {
+    public void parseSampleFiles() throws Exception {
+
         ClassPathResource sbomFile = new ClassPathResource("sbom-backend.json");
         byte[] binaryData = FileCopyUtils.copyToByteArray(sbomFile.getInputStream());
         String strJson = new String(binaryData, StandardCharsets.UTF_8);
@@ -37,8 +38,22 @@ class SBomGeneratorApplicationTests {
 		String validationTimeString = "2024-06-18T09:14:33Z";
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss'Z'");
 		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+		
 		assertEquals(createdTimeStamp, sdf.parse(validationTimeString));
 
-    }	
+
+        sbomFile = new ClassPathResource("sbom-generator.json");
+        binaryData = FileCopyUtils.copyToByteArray(sbomFile.getInputStream());
+        strJson = new String(binaryData, StandardCharsets.UTF_8);
+		jp = new JSONParser();
+		result = jp.parseJsonToBOM(strJson);
+		md =  result.getMetadata();
+		createdTimeStamp = md.getTimestamp();
+		validationTimeString = "2025-01-11T19:56:19Z";
+		sdf = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss'Z'");
+		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+		assertEquals(createdTimeStamp, sdf.parse(validationTimeString));		
+    }
 
 }

--- a/src/test/resources/sbom-generator.json
+++ b/src/test/resources/sbom-generator.json
@@ -1,0 +1,5677 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "serialNumber" : "urn:uuid:5fed4b99-43ed-3a87-bd9b-4a401f37565b",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2025-01-11T19:56:19Z",
+    "lifecycles" : [
+      {
+        "phase" : "build"
+      }
+    ],
+    "tools" : {
+      "components" : [
+        {
+          "type" : "library",
+          "author" : "OWASP Foundation",
+          "group" : "org.cyclonedx",
+          "name" : "cyclonedx-maven-plugin",
+          "version" : "2.9.1",
+          "description" : "CycloneDX Maven plugin",
+          "hashes" : [
+            {
+              "alg" : "MD5",
+              "content" : "9c7a565cf28cce58557d0c621c5ea4b1"
+            },
+            {
+              "alg" : "SHA-1",
+              "content" : "be882d5a22050bfa9d19090b1420c188617d0e1c"
+            },
+            {
+              "alg" : "SHA-256",
+              "content" : "698e0f37184a5b28c245c4065fd036dfce253b52f82fbb7113d81d36326cc249"
+            },
+            {
+              "alg" : "SHA-512",
+              "content" : "c0f0b11026858166f872a2eb54719492e5cecaa0bc9cd6b30b3ecb4a174eed220f4a1b5829d18d6734128e778d3cb3db7ffed177c92866133129cb29081814a0"
+            },
+            {
+              "alg" : "SHA-384",
+              "content" : "d80964707dfe5caca8c70521d5066f57589304c0a657e6fbc7c0614ea0fc7b3b3dbe7778361eee0f54ba111e9cb0ffcb"
+            },
+            {
+              "alg" : "SHA3-384",
+              "content" : "80bc3a275d9514bc457461ff52a72add8c7ecbbc01d8912efce57139016c544ee776981851be0a58fa977ab4221f703f"
+            },
+            {
+              "alg" : "SHA3-256",
+              "content" : "142317d6f245390f4fd2d0c100b16281b8dfc5c0c2cff86943bdcc97039cb699"
+            },
+            {
+              "alg" : "SHA3-512",
+              "content" : "af0fb9137c90b65d1a07f72e4d51ae509956cdb8800f35c961b037cdda1fe4a14ce3b496cef71ba85f1621affcfe29cd42704ae4191ff0b090a9602087c8997b"
+            }
+          ]
+        }
+      ]
+    },
+    "component" : {
+      "type" : "application",
+      "bom-ref" : "pkg:maven/de.starwit/sBOM-generator@0.0.8-SNAPSHOT?type=jar",
+      "group" : "de.starwit",
+      "name" : "sBOM-generator",
+      "version" : "0.0.8-SNAPSHOT",
+      "description" : "A PDF generator for CycloneDX sBOM",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/de.starwit/sBOM-generator@0.0.8-SNAPSHOT?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://starwit.de"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot/sBOM-generator"
+        }
+      ]
+    },
+    "properties" : [
+      {
+        "name" : "maven.goal",
+        "value" : "makeAggregateBom"
+      },
+      {
+        "name" : "maven.scopes",
+        "value" : "compile,provided,runtime,system"
+      }
+    ]
+  },
+  "components" : [
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@10.1.0?type=jar",
+      "publisher" : "OWASP Foundation",
+      "group" : "org.cyclonedx",
+      "name" : "cyclonedx-core-java",
+      "version" : "10.1.0",
+      "description" : "The CycloneDX core module provides a model representation of the BOM along with utilities to assist in creating, parsing, and validating BOMs.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "26fb8feac89e11e64c3e8e8ce41c2b7a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7a557068d90721cb73b4561b09f31f32a1e22dda"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4931d0aed28763ae9fa1c574e26b7636879abdc101ff81ce3c63ad905c99937c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d92bfb20a866f44cf1ea771bb5f7c41ee87f13db26e7d77bcd63a910745b4a79f1d5661dfec621891e41cba573e524ca3a759e8a1bc1568a41bd6525c1d4fbbe"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7ee527f84ff6d68addbf0b54b7b0ae4d0e67eca8e16495355136186b92d2db9bb219365436a29eae73db6b5c2afd270a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "87cb89f356b2ddd6b1d055b5d7ffebf6de91c2080e88f16b5be35c8807669814d1ecb39aff3ca1bc40a397c4a4b6cd94"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6533ae5b9c185f185987e1005a3373ef82b84c07a76b571c6ae4b73f4a968d8d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "12d41199cb48270344a771ad54aab4f4764fce672cb657bb8d20f363c998a669f04a49efa032f1a1f024adc1b090e5328ce387644d0db67010bf578036663737"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@10.1.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/CycloneDX/cyclonedx-core-java.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-codec/commons-codec@1.17.1?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-codec",
+      "name" : "commons-codec",
+      "version" : "1.17.1",
+      "description" : "The Apache Commons Codec component contains encoders and decoders for various formats such as Base16, Base32, Base64, digest, and Hexadecimal. In addition to these widely used encoders and decoders, the codec package also maintains a collection of phonetic encoding utilities.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7b3438ab4c6d91e0066d410947e43f3e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "973638b7149d333563584137ebf13a691bb60579"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f9f6cb103f2ddc3c99a9d80ada2ae7bf0685111fd6bffccb72033d1da4e6ff23"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a7db98db470e6ad338266ff442fbdfbc277ba1d07a591336f7d15dc49fdac884da7dac04d806628b12437f993d8b5e6a4b800a66590ff11936dbf8bedcd8e860"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ef0b8e0fbea5ee057b2c39114ff862a057d207d4dd6b4fd2f5ca96bfc039e76274f1dd02ddf985f1fa965736a522f5c5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ac30c88a6c4bbdfa79cb697cd179627d2addae842e48e2ab167c4f9c5475d05ef4743f58fbed254dd7abc6f3877644fe"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f3fe1daf04e63f556d72f4f59f149327b65d899d6afe1de770b42faae2e323df"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "29901c3e6394dd87f13a91b5432c678ac144cb6c86271b06c57c73c0480b23a4688d0266e2dd04abf5e1d148a2e80e1215dd87d2cb5ffbf2c023409f4f5f8f86"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-codec/commons-codec@1.17.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-codec/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-parent/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/CODEC"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/commons-codec"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "commons-io",
+      "name" : "commons-io",
+      "version" : "2.18.0",
+      "description" : "The Apache Commons IO library contains utility classes, stream implementations, file filters, file comparators, endian transformation classes, and much more.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8cce74ccf461cd6502ae04c908eca917"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "44084ef756763795b31c578403dd028ff4a22950"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f3ca0f8d63c40e23a56d54101c60d5edee136b42d84bfb85bc7963093109cf8b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "786778529435d8a14ab6ce2176cdf2b9ee6585a71893b785f26257122166dcefc7c4af3f612eda3974b06c16d06fc357178bf28b9b74010e9bc04c33221adc2f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4be7ad9b352412ddad3eb00f2e44f1236216d3e713546d34d71f3aa8e589b06636abf22dad0c28e11a0cd7b54ea0496a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d003d33c2cd37806d9d8f0576b65fd51fc1f02bfed7716279474556ef98abfaaddb5b5622762b64458bec6b57f77ceca"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "89019fd824ce65aa33554a848dce2ca47f09c3a261fd22c699342d99579e91d9"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6edaba8f76bd3e96421ae3611fb32414b064c5ef2fdefd7402f3052c5849e06aa6dfdd218a6df97b25cdd7997df0c9d643af960c4294f2e89dffb052b4b9d8cd"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-io/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-parent/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/IO"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-io.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.17.0",
+      "description" : "Apache Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang. The code is tested using the latest revision of the JDK for supported LTS releases: 8, 11, 17 and 21 currently. See https://github.com/apache/commons-lang/blob/master/.github/workflows/maven.yml Please ensure your build environment is up-to-date and kindly report any build issues.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "7730df72b7fdff4a3a32d89a314f826a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b17d2136f0460dcc0d2016ceefca8723bdf4ee70"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6ee731df5c8e5a2976a1ca023b6bb320ea8d3539fbe64c8a1d5cb765127c33b4"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "dfd5ff7fe7f852b9caabc81e5a00e20616f98405085f059b64dc2121feb5fa6cb327e11a3d2f954c079811c31f6fd484e90f932d45078796fbfa7dbf1f1eb5aa"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c6ed55a5c2b05332890a43a3ea73b30f42dc23c92ebd054a8b0d29ca8f49fb9361f7325cfa90715be457804b087221b5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bb9e148a87928c3053bcccee361d5d8d81b3c6ea41a390d96c615afd242409f909361c945f3b4238a297e4ebb2ed413b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f28f34565f25dd65fd1a47916e917df9e3ff2c6721897ea57391a238227c96a2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "4c8e7a5f10d091bb240e7eb59287d0e4e4420e7a2d2be2b8060111e479540ffae89040377c99ec7f458cd54e1ac0ed0778951cd1f34d5d90571b8a303fbb9baf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-lang/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/commons-parent/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/LANG"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitbox.apache.org/repos/asf?p=commons-lang.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.commons",
+      "name" : "commons-collections4",
+      "version" : "4.4",
+      "description" : "The Apache Commons Collections package contains types that extend and augment the Java Collections Framework.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4a37023740719b391f10030362c86be6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "62ebe7544cb7164d87e0637a2a6a2bdc981395e8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1df8b9430b5c8ed143d7815e403e33ef5371b2400aadbe9bda0883762e0846d1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5939c9931eb9557caee3b45fe1dd9ce54cabdc4e6182ed7faac77e1a866dd0cb602bfa4ece2f3316d769913366106bd2b61bf3bb5faad1fa7d808124c06dec0f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "74059fd8f61c366ed448e102256fdbd1db0d690501c2c296c80f3657a2c0d8ade3dd9533b1431cc29786bbb624195f46"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "15034fb39842620bf3b152cd90bce252644ebc6a29fafd6dcf5e1f3925f09ccea2ae4e195817450f996b25a7081a9a3f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "1716630a207a8f4a83bf9ef19245f46c87d62bfebbcfa1227101e6dd51da8fa5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c290c98c7b5825d024644ec1162804a1f9ad4da3bb5324d147ddffee6cc79e3c0ecc3825d6116502f2ca292ec80c4e7f8d49a03542dda8f4d58b0dc8228923c5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://commons.apache.org/proper/commons-collections/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://builds.apache.org/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "http://issues.apache.org/jira/browse/COLLECTIONS"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail-archives.apache.org/mod_mbox/commons-user/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://git-wip-us.apache.org/repos/asf?p=commons-collections.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+      "group" : "com.github.package-url",
+      "name" : "packageurl-java",
+      "version" : "1.5.0",
+      "description" : "The official Java implementation of the PackageURL specification. PackageURL (purl) is a minimal specification for describing a package via a \"mostly universal\" URL.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "90856d8bb5b17e08fdf03b6a2f93b81c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e6bf530f52feab911f4032604ca0b8216f7ff337"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e45551727707acc0c56ac62d56964332ea0f138d6cc3656d988b9369150f5247"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8064df400154caa110b8845bd17e6cea2683307e575ce88e40d7c0c8965ea0af6c150a376d8b9ba7354676c41b52c94535f30c6e830447613299ccf5fc7aa959"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0597100022f72e020c9d929bf57ecef91af7574610fb03b4019feba4b25f491a076f03577be2009e66d9001c4c0f8ab0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bbdd55a31a4755ef589bcb176283fe03e3c9089d315eab577fef3a9c2d02e632c6ac3fdebbc90a2f0f8ed7974b9f397c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c9881b69bde35ea6ff4006877b9fbf91462f911b5b142aa699a45a00867d413a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2b9caf58deef687a9bf01abd61a7af4abdb61247a8a966683a18157ee948f1ea424602598dc8f665bf24f7e1e516866298ef0507e9d697cb20dcf60eff2095ca"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/license/mit/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/package-url/packageurl-java"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://travis-ci.com/package-url/packageurl-java"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/package-url/packageurl-java/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/package-url/packageurl-java.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.dataformat",
+      "name" : "jackson-dataformat-xml",
+      "version" : "2.18.2",
+      "description" : "Data format extension for Jackson to offer alternative support for serializing POJOs as XML and deserializing XML as pojos.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5aa50d2b48ea710b8844ba9367efd25d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "069cb3b7bd34b3f7842cc4a6fd717981433bf73e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3a5c26f070b9974617f4b103b9561d4f5e3f4f8cc60162d4e0cd3e172c776af5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "598f8f899a98b54da430f0e3ae71f8f46f0f6ffe5d1b5830db5609a31898e68be1954162cd8fce37e257d2455ba8ea0548334f8d0f10178aaaf1d02a1e359138"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1212410a2747ffa75d1a6e6343876b3ed1a45e21d2941c9058c7ef1f47935d4c02f9609a103a47e4ba5c39b93b12d2bb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "81fa6f5f86e9c3cfda740acb5e257352a756721dae208692fce04575649e8019b381d215958eefabdede7cf4b358469d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "169047c6461509cf7a87df9a29b2f57501c5e5ff58290ce6e0bf0da6f0bf9f4e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b4ea2a395d883b9a367f24a47e1eabf03c398cf362d1493fedcaf61b1397092b8d70b51ad3d613759c0a73116d60f8b039c62f999ae503600974d3cb97fb48d2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-dataformat-xml"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-dataformat-xml/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-dataformat-xml"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-core",
+      "version" : "2.18.2",
+      "description" : "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "bf935e6eca3a57defa13918661905cb0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "fb64ccac5c27dca8819418eb4e443a9f496d9ee7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d8054ae7c0d1c2d2f55d28e46026ebe5892881f3fab5f439233184381c3b4a1f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2223f6d8235c6831b488dd2723a4569e4dab6c2371f0e39f867b57a3a443e093d1fce05dc070a350fa306d7e952888cb09c7c816254147b01083d122964fc3a5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7c5183b4e0ceb3d9dd089e29253832fdbe5f126a7b8c08fa66ab46f5050eb3b8fd792e00bd914f49000719e547586e23"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2a973e2dcd1b65eb63f783878c542fa804254c880d47180717cd5ab239670b529c61ca4de647d4683cf4b459b6a7f5df"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c99bd2cc1f13748357bf002d92d83f9f2d14d777c5e3fb7ed38c6891c76dbcb8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "10b0328f2cd2a347f8c3eb8ed1967036b8940fe9b444ac27ffdb66bd373686a13fe7ec7498de5b81af1a301ed4afeb85aece0afb782aa6cadcf78362fa7ea5ae"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-core"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-core/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-core"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-annotations",
+      "version" : "2.18.2",
+      "description" : "Core annotations used for value types, used by Jackson data binding package.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "79d38d3c51068a2bbc40268d02f80763"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "985d77751ebc7fce5db115a986bc9aa82f973f4a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "581bd61000ef7648943f781ca05689e56d03f6052748365a8e2b3a9b5d3fa32f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d375e5761052e202e409400637cdc9ce0f45cf01a90628f36ca3c81757ac30695cc6e60146cbf14685c5c50912ad932564eb794ea76ab8461ce1786a02eab867"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cc68a2e188dfb8a3687542b7e6b0d2b8323536dd82716a545f73320915e5f9602cc7a3c3d67a15f5adb579c31d5ed96f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ffcc40615a2d6f0c0382595da8601f7501dfb78f6f78718e9f05f309253379e9d9101d82bc7aaf8735746eafa190d8c9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9cb3a706d1bc0401a7bdd9c42a6ec048cd7bebce9f60f395e44c254a67ea230b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f1a5af82d49e1db5898b4caa487a4ae061cf31b5db25e2172fdba59970dab3308618f7e34f6fcf0842b7c9da958c274d69022d10d85f3e862be88a44ef8b7fc6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-annotations/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-annotations"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.core",
+      "name" : "jackson-databind",
+      "version" : "2.18.2",
+      "description" : "General data-binding functionality for Jackson: works on core streaming API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1b56887bcd3eaea1ff710eb673e610b0"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "deef8697b92141fb6caf7aa86966cff4eec9b04f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4b364e6850dc89172fcf1d4dd26b8ff5488eda44ff4657e22dd265203dd5ab3c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bbdfaaffaaab2a032a754cd9dade06552e9f79fd39ae396873315415219b37e0675fde0a02953efe0701e17be4c282b118a96fcb752f53ca37ab89624f0a52ac"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "77607f963531b8b7a963e0691ec0196d0877f13763fcd7485fbbe14a37054a9babd343aecc96c8d29ec2480546cd1e4d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e02fdf4bba51730989da3efac6e0dfce5649215ec78c7d21713386d36874d621f65ea9881399ef80c87a9436877453a1"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ced61fd9988c4418e98f5bd061a3aa099dd4e0a0074a272e87803262c2177bf8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6f6610e9bbbfd344ebd716a7709a19bdcf0180f214437473602db312a5e6d6e592bed40776ce9a445ab6b7b5c0fd9291fd11257a6b06e5dbf4b971fe996b2972"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-databind/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-databind"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.2?type=jar",
+      "publisher" : "fasterxml.com",
+      "group" : "org.codehaus.woodstox",
+      "name" : "stax2-api",
+      "version" : "4.2.2",
+      "description" : "Stax2 API is an extension to basic Stax 1.0 API that adds significant new functionality, such as full-featured bi-direction validation interface and high-performance Typed Access API.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6949cace015c0f408f0b846e3735d301"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b0d746cadea928e5264f2ea294ea9a1bf815bbde"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a61c48d553efad78bc01fffc4ac528bebbae64cbaec170b2a5e39cf61eb51abe"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1c0587ecb4c5a659ce2ae1fe36ffc12636a8ecba549a29f2cf91cb4d1d36a335c05f35776f480488d40d894230389f76aeeb363887026c6ef5c565995c17b7c6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3b617db8307a081df858a4110f5b8fec51c06355762506cbc4be5557fb06959f0499f7e672103d46f71c66bae472a7bd"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "22a3150713f7072962e26c286a1ef97d849b10d7f1251c56ae34252f247127b56dd189daa758c64776b4196ee0060517"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "174868c81672068b42ccde35310d4dad60f457b795101e99588c28b0eebdefc2"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c88de5a2137e3b63b632ef24799a677c998b76e736407f1e8c6af85d1b6a94c76bc20d26e6cac847d8383ab6760f1b5c2ae7574fba21e1e6a96de7cdd38f0e39"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-2-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/FasterXML/stax2-api"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/stax2-api/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/stax2-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@7.0.0?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.woodstox",
+      "name" : "woodstox-core",
+      "version" : "7.0.0",
+      "description" : "Woodstox is a high-performance XML processor that implements Stax (JSR-173), SAX2 and Stax2 APIs",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "497e4f32ca6f31e5c1bb8e9405831e74"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "beb19c02e7e28a8a4acf4a9cc8c3280ec3b94722"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "eeb3853282c24964a93a6eb4c1bbcb60c8d09fd8e0ffc75ab64ad21045a1fa78"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f7a687d2778fbc7081ef5f0bcc1c780d52783446d52e3598662513608647096e487d628aa998345c03fb9691bdf3768341bb8126f132c2721de33aa5bd802ec1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7b1fb07b52ce2307ca0cb15921fa37d8d41e80ef63e5d36813933a1fe7a2b00d456c364d91f26ed030df9c7b76a29d4d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7cbfa405777e00b798d2d2379688ebd8b3f4a5e483e9a9797ca38cb747480a2edffb33c2532fe87c91d1afb2f32e9f11"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "62a20ee9764b9d19aed1b0df6dc850496409f638ed152dea65e2a5ed73d6cb3b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "07d1b8b84aeeae98020fcb439b6ff69c34868741a739d7aaf7cdbe7fc76af1d204b114422441a7db856f3aff3691399e7e1ea1f67ce48e1b42267352767ba11a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@7.0.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/woodstox"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/woodstox/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/woodstox"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.networknt/json-schema-validator@1.5.4?type=jar",
+      "group" : "com.networknt",
+      "name" : "json-schema-validator",
+      "version" : "1.5.4",
+      "description" : "A json schema validator that supports draft v4, v6, v7, v2019-09 and v2020-12",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "98778fbb12193b995880f2d38527c384"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "db9218932bada0485e137b86e25ce2b360ff8bf6"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "fbbf8940c1a4c210dd58d1b7250420b32fa164bdbf31c3b077641327bd37faf6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b4dff88540d64b9a071c1b56658b056c11ebe7ab968ac8d1f8ed79d779dd13a9465f50b86bb0bc93b869d5a01af817cf227fa6a69d0ee53b866149b8d431b92f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "519fab4ab3677702ed33ae65ac5c61403e81f47e82c69acdac1c0c0db7bb5b84e75e98561ce928fa582e8fe62b75a293"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bec765fd0ccffee15d469dc353f8ad7b92b325b7674a2f30b6af98ec34905606051e6fe9ea696a61bb418a5bab2a014a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "200b1df5b38a69fdf6487c1235fe392ec77fee2fd9ea67a61662670424fce8c8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6bdae28e54676f792ffeecef96364654a866a41df49a0ccc055ea4a7767ca2877c1b4cc36fccc1de691649a3bcb805d8c43d35c46d16be353d8c5ec9c6a15f14"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.networknt/json-schema-validator@1.5.4?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/networknt/json-schema-validator"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/networknt/json-schema-validator/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/networknt/json-schema-validator.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.ethlo.time/itu@1.10.2?type=jar",
+      "group" : "com.ethlo.time",
+      "name" : "itu",
+      "version" : "1.10.2",
+      "description" : "Extremely fast date-time parser and formatter - RFC 3339 (ISO 8601 profile) and W3C format",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1b839463605516af5fb01749a818e27b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "320413cc72bbcaddf543826909140f2ee9afe76f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0424b2ff0c20265a084a32a4907521b28e7b86af25d131987a6b31ef63b9687c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cd109e39af788d88543f0867fff48adefe23b01a77b4a5f1963b117b125b71c9613ba3009f69d8f1131f5066689e3f43457cc2a8f02e827f40502b5e13bc3794"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "2411434f4e66f288d86fe37039ef1017adb28ee0996f8836a86571c547f6351561e127a49309a336bcdd5423b99cd2c8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4d33f9a2d525d0e3778c68526ef75a141a239e24a396b4456afc6fbb742415e7c801b1f8b4582fa26664b54bd69e217d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "887b21b9dd007248b77ef52db5dff20dc2cdf4728b6aaac32b6612bf1952f118"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b3ee4789007071421545ac04b51263946d5131787cc62bf2994b6fbace70dc10211f0382f4d0d4eb6df8e2b7da5f93782fe005fbab8e6352ef906819958ec80f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.ethlo.time/itu@1.10.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/ethlo/itu"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com:ethlo/itu"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.dataformat",
+      "name" : "jackson-dataformat-yaml",
+      "version" : "2.18.2",
+      "description" : "Support for reading and writing YAML-encoded data via Jackson abstractions.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "823869062440ee6a273ca421727eda2f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d000e13505d1cf564371516fa3d5b8769a779dc9"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "381a1c0711e4bb88561a6c0008b5a945465628ca07764ccd66a0d97ee07ad612"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "65e764410a1d89f75b351451f1b77c856f6268775c94f66aa4ab351d357747f0cdf4d533b88697fff585f4ce0bbff7ad6437146761238f08cc37000573c68cb2"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c45aa1c45e651f43ea710c6c1d5e4df993ef3fb5b58217c21b4c07059b46b3b008c8c1762bcb29636f43c2429b7750b3"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8ef1ac964c5370d5aec210b0e5764d030043d4e0e5cf78efe2a1630da9ef5de4dfc5d4ae4115a65bd7d3fcb24a953b6c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a7a18fbacc35d2054708c0d2cf21fd6041169a50ce306d611aff33c5f2fed1c5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dc5b3ceba654b1edd56b51f64d666fb02bd2701f5dab8285e69b754ee1c146a3945ae6c8d595e00374f7a1d3e7fc52929fb1d7de8bfe926db338948d8847d832"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-dataformats-text"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-dataformats-text/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/FasterXML/jackson-dataformats-text/jackson-dataformat-yaml"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.github.librepdf/openpdf@2.0.3?type=jar",
+      "group" : "com.github.librepdf",
+      "name" : "openpdf",
+      "version" : "2.0.3",
+      "description" : "Open and Free PDF library.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0c87ddb05e934db1ddcf824266172ae2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2dc1fc7eddda56b16621c912e8be60b85a8d305d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8dcc234a767557687b4eaa66f067de09d6e9bf8c8bc7003d606f230423fe7b5a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "14c3a4553653a7b792b55104728bec806a5036fab94375aab86a3f9b6d1e4b967f6b70a43bfb0601e5bdf08cb6187a388861163e9c97a986a2903191953321e5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "301d75e8c5e030496996eb3e96a3e6e804371e5c1c22dce515856824caeae4d9b53cfb0e17967cfe2d878c72d24faf6c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "786cf6e194306c53e1997a5a3039cf9b276c2b5d596190d4cc81283e85f67286132d77f8c8aeae66ba01237b8cb9e8f2"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e7fca1f9f59e0f6b2924527366e11bf45b7e8bad9554dc9c5bebd815b2c9eb6c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1579b9a5d7d0b4aae3ce8171ed4779751ef46bda37713e05077c541c6b3bff0b763b20836876d17739f371e0aed80cbd5a505ff676a594edff0c68e24ae6c85f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License (LGPL), Version 2.1",
+            "url" : "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        },
+        {
+          "license" : {
+            "name" : "Mozilla Public License Version 2.0",
+            "url" : "https://www.mozilla.org/en-US/MPL/2.0/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.github.librepdf/openpdf@2.0.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/LibrePDF/OpenPDF/openpdf"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:https://github.com/LibrePDF/OpenPDF/openpdf"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-data-rest@3.4.1?type=jar",
+      "publisher" : "VMware, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-data-rest",
+      "version" : "3.4.1",
+      "description" : "Starter for exposing Spring Data repositories over REST using Spring Data REST and Spring MVC",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c6b571078d402e1c4583c576d75c2349"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c7674e22f9c5d6bcb19d7fc553fc46205918f577"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2b1a8b538a01de63bc248bcbee93ea6a553cf5caa1f005bf5de1be42c4611c31"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f0d1f13d96263c879d2b3f318aa53274f080fdc47ea6f6351ceb450fa1a7f42eb0bcee4483c173559aac6292ed8e999c21f74b7692c6a488633e7d2b4b4895e6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f6e30c11398063f13512a15ee787f9343e2b7ac8aca6fa52a1c3490d7f5f3f93051b945a11b1e860ede3dffed8b0ef7c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "41d9954e50c32dc8ec8a07eb9400f307504fb70d3302964a39c121a637ffb74bc9a8f1f5763a1a6b6eb6e0fcef3bb3da"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e2d57ce4803d15f59da620bb4147021ecc1a8362e696cc9a594a9206b43db7b1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fb9f6ae3ee48a511598a506150ed2abd99c630fbfd58bfb8daed7982db51c2be9a944adb4f1ff151f2b0721c4069f546b3155deac9defb4e89c94c36f8a0d20a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-data-rest@3.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-web@3.4.1?type=jar",
+      "publisher" : "VMware, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-web",
+      "version" : "3.4.1",
+      "description" : "Starter for building web, including RESTful, applications using Spring MVC. Uses Tomcat as the default embedded container",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6bb883295af01365da52b519b931e1f9"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ff7227fc62338e0f6eba3f9f94c12eb952d4da95"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2a8d7c6079209b47f50b2901794988a1cd152aad59f06bd4c31e202ef908937f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bf5e1d06964c0fcad98b19125b98a42b31b55af7c6d4c8eee6d9f562b33ebc4ae5b76f2f6dbcb656a476f7831723e28554304bb26f2624e31c66d5ab98edcc42"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "91b183f60d5220e4cf208d5c5e0310b96e65da78cd9de334d59a7ff9476be296960bc1674e6f864d5060c4d489f17e93"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4f13fdd59cfa688f2b7e8d24532244717da511b8531666a37f9ed0b95994b8ca5b2dca9bc0bef0bef8aab223e4a23942"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c1ea5edb9ff3748b65f7a480120845c9bcaacee042f5ae293ba48cf89b92b2d6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9f7a63f75cf62d0416d57862604100ecf3b224d79f20e70d64ea48a7600666352bcc6cec9af907522913b8ad4d3ce204901c08bba61745cb6a70bbdde510a8af"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-web@3.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-json@3.4.1?type=jar",
+      "publisher" : "VMware, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-json",
+      "version" : "3.4.1",
+      "description" : "Starter for reading and writing json",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6566e30fe7f10446c43ade44fd722622"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c1d084f65d8d9f2de9daccab47c4f452fb0464de"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "9ed29b5fa76d96f3a6f0756cb91ff7def2d795736d275a540c1e18fa9ea7b460"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b2f9a026d61d6253611fd840bd081e145afdf3547a49ed8f7728ef94b48c4189d03b8e1b02f691d32d5ed8032d1ea27e8365077ddb6753b79eb68ea195b1bac5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f2c0fc12b015551f64c564baabe0a02d8ca994fade6e521600f58210f0768373bd5499decb542798981ccbadd08dbeae"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "3d4530e834d60b7de1268857eb71e8f97f009f6db321ad0064ad027177d89a256c8f7775df363d2862c3afcab2fdbe18"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "e5ddd1a6622c2e73a7cdd0d3cecdecdbea5ac373c681762474898edea9b35512"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "47174e60e9e4b7ed6a79ce206ee1802935a966452cbca7159a23eb5ddeb6d1c2d72f9ed12e17c5228429ddd2f395aeef6834201897a8134e1439af6fb315676b"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-json@3.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.datatype",
+      "name" : "jackson-datatype-jdk8",
+      "version" : "2.18.2",
+      "description" : "Add-on module for Jackson (https://github.com/FasterXML/jackson) to support JDK 8 data types.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "54d2dc0c44a7188884e8f22fddd947f6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "9ed6d538ebcc66864e114a7040953dce6ab6ea53"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "f30d77f5826b9e9813342e84ab412095ed4ed5cf4fef6f93cebb848cb0fd0294"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "50b79ee59b1f98b607978adcfbcd339f7c260b8f9717c91527fcfb51440509750c5da6afdf595d84a28dbe93c2a53115383a84c139a9f0293bbae64d7f0fb166"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "6906f42e7130639d2a77ed11421ab6406a073a535e3ea7598d851d9d6586f138aa47ee2fcbf6f4bbf9107951805a087b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1b00b05dc9e8db706d43f500a4aadf6846f36ec882c16c6d8ca7e5184530c6767062eb4cf2e49ab4aaf3f02b4994012f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "adc481d27fefce0687b41cf548783a8fcef56accaa2662651cc6e70a8f8c3ccd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1346636a5024863d670128e4bfe48f42139384ca3cb34e8a967d88c54c6bf8207ac15746f7da081e1fb043b8f30a06b0ba4fbd4157438cdeccf81c4c3c01c3f8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.datatype",
+      "name" : "jackson-datatype-jsr310",
+      "version" : "2.18.2",
+      "description" : "Add-on module to support JSR-310 (Java 8 Date & Time API) data types.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "aaf3adb28aa9de74b3bb87118f93113f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7b6ff96adf421f4c6edbd694e797dd8fe434510a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e2d202d4606e23aeaf8a5a9632db06f5fefd5b63d251c3f503f9faaa78530e5c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bc1cb3e193996ba0b876baefa99122672bbe617f2de582f5208609efb1bb5886832857406de5b0fd7969fce8c07dba0a672b3f077bac2f7efbc3d0cc252c1ee9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cabe852eef9298f16699feecd3ddd9589712be714c4cf8d0a581edc84d40ec4e72c5ecdb676c5f7a6a8d4aa994295a31"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0564445841652897541e3ff99accacc4fb57887b97189938e6a5759de1d9a79685229b255b798f3e34cc098bb966807e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "9941830e2ad393b33e3999095cab945f4e768b1022310d13f9c57beb8817e429"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bb85164ff9331af6c8d872712e6f3b1757855ef73ab81e24b4c8631f3eae1bc187aa8e6fd68b60f44808b2691eb364edbf55423eff1be3040b3658d9f656a3d1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.18.2?type=jar",
+      "publisher" : "FasterXML",
+      "group" : "com.fasterxml.jackson.module",
+      "name" : "jackson-module-parameter-names",
+      "version" : "2.18.2",
+      "description" : "Add-on module for Jackson (https://github.com/FasterXML/jackson) to support introspection of method/constructor parameter names, without having to add explicit property name annotation.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6f9d0d83bd13043d1d50be46622d914d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "72960cb3277347a748911d100c3302d60e8a616a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "67a6a4b6b91f3d450df21e77417f400be663be0cf528e48349ccc381cf74b3b0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "f3c7242b975cfc0420b93ae33a33c5637618e998d2b7cb8d6e8ce67751faabfc96b539045b27d1ce2890cfb37c0b634ec4d382bc459bb755fdd14578cc58b995"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f3e755d3f10bbf3ced36fc1a05dc099cd63f64a6811e4dacdb533d50efc8fde31093b983112eb4f23e358169eec3a8ee"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "a97911da05b2c871f392e3257790ded60a3b8cc6fc8646cd7057b01d49c5276228470a5c580735dd458ea42c51ed4347"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6e2e50bebfac57244d67ac724d8dc30ea98b79f08c55b809db5cbe45dddd5007"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "78f3a470515d07d7e66b38e23da6d7a3904dc2dad316e21a9884c3e37e828a0da725be3ca10d4d7d0bd1aa4d01378884d194c3cfaf5ea7d42e85852b9739ded3"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/FasterXML/jackson-modules-java8/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "http://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@3.4.1?type=jar",
+      "publisher" : "VMware, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-tomcat",
+      "version" : "3.4.1",
+      "description" : "Starter for using Tomcat as the embedded servlet container. Default servlet container starter used by spring-boot-starter-web",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "db03a88193f0ae195d0ffe4ccf9ee534"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ac4bb51582c57cfb0d2beb102a76fe1a4d8b8b21"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7b64ce41136c44a3e81b0d49770ca57076173c4cf024421ee58da707a41f024a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b101debf1930b24565e8194cbdfb0027dc67f800eb3468790b916d753fb51e34f413abb975967de56d7eb38f26accf8f7f984d08d2ec3434efc86c360c60f943"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "39ccb2929a0fb105132d39be4d021bd8540e175d97b59947eb5cfe7608bbe53c263f4101ab4b4dbe8acedf1ba7315a5b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4122d5114d6ee63a5d65df336919e4231514a0fe24f7ed0b8201fdcf23919abe4ccab146c8e15c14f2348e4f56b2584f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2b2e1aec0946bc9a948e1d50a89050bc0f69cf151c1075b448d2dce0b77941ec"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "94ea54bc02087f20b8cdce48c1c5b97653689507767107c0d879105cc3bfcb758e57440051ccfc70d6c5fbc4fc33616dacd95595cbc1794fa447218bd43c61c8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@3.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.34?type=jar",
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-core",
+      "version" : "10.1.34",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "697a86b4e96b0e0bfc7790d4aad03fe7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f610f84be607fbc82e393cc220f0ad45f92afc91"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5817bbb6c3a8d405a9f51ea0d402786114b4e8fd6d7ac4dd23ca34ac8d38a593"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "caeb3fd53cf505e1b9c2692e71f6696f4b9bb6f113a63f5387c6edabf8ad8477e8d058bea3b12a100de9c2cb0253a6d1578f2c4dbfbf37720d17bfa19078b9f1"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "fad6c009dbfc6f67dd80eb134c7659aeeacb5465c5a0895276a871d76d77cd86f322045d94b60026ea873ed669176f1b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "ddb356833e563c439a1861418e3f56aa16e9dc20ebf56b1f94b732ebf45a8e33e09adfc414e4854221bc153f191bd8fa"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c7ba6c200c556718bd16820b16db091d0ce38468b4c07852efffda313d14311d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b4895d6b9539015678adb8ae5f8883a2cfe66147e55ebeca9ceba7a5a6c691384f37c1774ee6c37a17e7178e1dc5b36be2986f7f4bfb6e6a5c1e1b2bef1af141"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.34?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@10.1.34?type=jar",
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-el",
+      "version" : "10.1.34",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0e6b9caed9d638343f532ccd365a9708"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d2b2daca3bc999c62e58ae36b45ba0582530fb25"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "54f10ed773387621f5c4fb7e526c2d1674f5d72fc4d86ed87238a750b7fdbfa0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "55b6e173c1a577a8afd9457b89df5d34af19dac3db0291de54f4c2342a6138d6c9e1c4096fb978487e13debef904d93227b5d3af15d12f69587e93b07710c66f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d801eef46d1971fea94e93bf868ff20d599a38a1a3f498bbe3a1eb21bc7f1c71a786b5264e79b12463b8fa3ca79f9400"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "70dae2d8ab3a84e68a0eb4282c78630f3eb0ad17ddf35d262372b4e2ea35ed7fbe919eb72b9f297c60ea90654f25abdc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6be61f0e18aa213bd7fb60f1baf32a501683c67bf33438701304b2ae1bda0b43"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9a3f3772dcc3a72f78e70ff7fe13067160d4d1e7df1a28b4c5a5ce0cdc36c6d1f220ec5f7aa12b608e401634f4d2c593d1d42bfe1ce11b17dddeaa43e662fdc4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@10.1.34?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@10.1.34?type=jar",
+      "group" : "org.apache.tomcat.embed",
+      "name" : "tomcat-embed-websocket",
+      "version" : "10.1.34",
+      "description" : "Core Tomcat implementation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "06387e32dee7984a6cacb765d8628c44"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "eef6d430f34b6e393b8d9e40f10db9043732b4e5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "acbb59e0ada75ecc5d82a0513d453f036d87b53eed3c6537db3fbcb54105454b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4360fca983adf3096f07af1d3c8ea77281d041b4537f269570af71f80027a4e5759b8e7073c72e94eb0ea01891f7f56c533e89267cc394fa14ef402837b3f528"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d26c8f21e5ac69396997d9f908363b3f88e6a2aee0723b8eb8758581e937195311b5443dea35282657463a0b3bcc0b93"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2983ef65a195ec65500225316dc52327301f8b2ee50f36df9b2b510623703b68908121b21f364fead61dd2ba0dba2533"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "df86cdd084bdd049cb646e324b28cf102add96118cada531539d5d89f00fd9bb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "c40180400ad7b42e8ab8929c0c31b45b906b0f0aa432eba56423ff50edb3e46ca70cf7e3c2ed6ef373b53b3cb88e43fb49bd51481d12758eb81174c6d0f63d3c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@10.1.34?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://tomcat.apache.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-web@6.2.1?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-web",
+      "version" : "6.2.1",
+      "description" : "Spring Web",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "66614877f218caec4797e7bd5559198f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "877acb94c5b3a0c92e652b6bebdfdc7c60922ac8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "6bf5a036390de810a4e78a07a17051e7f222e802b2249bde18c05740504a7888"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0d7813fe50d9c58df8236c8c5f6f4e6c54314b68b2f7bb1adace52eb3fe32d6c1847be4544cf6fb2ba49b60a7b0c4fe8737c2b0e9009262ea5e52ba5b04bdc2a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "65689dfde823f04dad962f482d8d097a20b602ba58d767073caee6153b6d54e330d845818fb00ea5a813bdd7cb91e8a0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "4de45dd8b11e3e41c45f357961801b7d9850b97d79cbeb1b139e77608511adb77db13972693005ee2f5eeb81e06ad2d4"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6c8452b0d954b0b6af3fa562a798ca5e4a036cf702659765dd3c93859436deb5"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6db967ca040d4f7b37c3757dc4dd1387e793ddb84c5582a9979ddf3223f1a5dfe4374a64c7e82c597410bc40586003e259ade79a93c4fffeedba07c0fc4fb9b4"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-web@6.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-beans",
+      "version" : "6.2.1",
+      "description" : "Spring Beans",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8478f819bdba583b002b45fcfc44c7fb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ab57ec03ba6900075bf28e3cd70ccce173205b8d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3afc928c036bc557b650df75ae33ccdd440bc48f9184d19b463df0d2ea74c509"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fb2c4f13a60842691afe70d7537d9451800a38809689717cb0033f8f600c1709477b57cf0afe6a12ded5ddc4be8892058abab92a3252da134d3e65b0ea9b4d69"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "764f3102de051c2bb4616d9e6258f5654e265f1bcb6535c44558074e6ef977fc196bb8700967f1d7d6b54ed7ead875b8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "5e00f5e9f469ddaeed07ac74cb6b3c15e1031d8f3ac7076029fcb43402a34c9c68af69e59196fb1d05efef195ebc93f8"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a19cc80ba373c6a7eb3927112a85517ae33b6f16b8866c052d008c1bedd1818f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "2e8c339c6ee204a08e6d998690f667163bd1be39317f59932c419d16d1fc880d6b29e8bf8e343b5aa0367b7e2a34efc5dbab4814f298521d2685a8d6a42264e1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.micrometer/micrometer-observation@1.14.2?type=jar",
+      "group" : "io.micrometer",
+      "name" : "micrometer-observation",
+      "version" : "1.14.2",
+      "description" : "Module containing Observation related code",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b8dcb10fa3bdd5ca79dd8763102abdc4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a9cad29cc04c0f7e30e3e58b454d4cd47ccc54bd"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7c639c9a028327f362360c3246e50613f8e120031575ceb557b2ba5feac917aa"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cee5d22b7ba65a434f1e66aa50680f4d04d7f96494b0bee3da09931e56864bf9b0e310ba931e95754129d9caba75879bf066616172029e24360b4286b9ec0d58"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "838614d3027acd3fab95ae4e0db0c117b5bb9db4fc73a7eea47ef9900c59206fc1bb8f98d53103ff9ff43f6f1c9764c4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "67cdae4e3c856a92a9c4b01d88e3e28dd193a848f1adb8c5a6b46a8392483d6c2d4cb23f65f3863d3eff745741daba1a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b20be7b4eb99c5beeac813eef1df34f35b21232a82533601eb2d754cb94290d0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "6f21af440da1119cf5131df41eeaa1234f2ec7b0fc200ea7c09760f80ac56537f481b1b8f1aa86057c59d862ff05016cb17352b1ac81f7be6e69f089fd84d8bf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.micrometer/micrometer-observation@1.14.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/micrometer-metrics/micrometer"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.micrometer/micrometer-commons@1.14.2?type=jar",
+      "group" : "io.micrometer",
+      "name" : "micrometer-commons",
+      "version" : "1.14.2",
+      "description" : "Module containing common code",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "534f518acc64c3bd5a9de436130f407b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "69c454dbec59c7842cf59a534b7ec03618d75b91"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "d1ff22870b51a59a1d3047580a99c703b165e01ae933c06b713ec9a1826cc753"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "ab4204b9d611ff4713d7a2f22aff18080b17be30f9feb2dc476d063a9a85c0fc1a2aa02ab333f720b13e5ea2ea578b2d5654d4f18289ba95ae459444a407fc37"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a4585240afa971b6bb5cb5b7e362495ba7452b7ff0f99abd986c0663ee13ef88322c203b7fa72f72c41e25c722bb0d65"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "830f5b63d85c14fdbf409820d653963833d6ae91c376b19e8026058a5ca987dcd3fbf0d27df96441d1b33067e658cff7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3cd21ab298af98dafc2f8396906d3aea0b8230bda53ceeccbe8565520e123227"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "72be10a1fd04376671c1198394b53c88ceeef599c415e90ac28de394f00e76c016bd7c5c0af3a8bab58fa8d9741b9842303a3d3a7583d8d06ec0a9455af149fb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.micrometer/micrometer-commons@1.14.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/micrometer-metrics/micrometer"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-webmvc@6.2.1?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-webmvc",
+      "version" : "6.2.1",
+      "description" : "Spring Web MVC",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "44c1d4bf31b0c81eab2ba9e5d27d80f3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "44bdf7e5641d44044ac52d7bb5c1fc46004e7754"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "42ba27630eb6acb1f2e236ced1f5679eed6037277b06986d7e2cf009537757be"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bf57a1d95c8cda46bdb00969f92199207bbb6ce506f5d4a7bf6c3ccbbb918276ca2f39daf125c1a11277748eaa93909cbc7f3891c6cfaf974b2b5798c1e67c31"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a26911eff831f2df198091273bac8097a778ab14b94f5f82853eecfdc1cd21c627781163eea1d586d73c17aa2460065b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "18638ca22cd601e8f7c9ddbf8cebc67d8e1d65056f60aacfc9f6c80b336469ea75356d1aba7fdd713c272332da1aeeb7"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "eedfddbc43235084ca1c3fc25ab58cc15a527c3e9168cb8c937143671f15dc4d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fd869aaa2e7d826472d564d016ed0b2b0f947335f42685c37a99b878ee621de022a3e27d0b8beb79283af79e993dfe759bcee923b1835f664a49c27f185261db"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-webmvc@6.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-aop@6.2.1?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-aop",
+      "version" : "6.2.1",
+      "description" : "Spring AOP",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "ebfcdfe96624e5a3de3d0d6522c8593a"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a9384de38fc00751084446ba014a0c4962240244"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a9cb0dddec1312c1cc6bc6a1762ad880f0e8b2a82ea2243b91abf2ac9debb86b"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b5e2122fcbbea44afbd0226a9b2a84a825c5c2e6e850ea7d9754636f6a8afca3df7459c1c3e284bce167b6cd71c5143aa75943c6d3de8b76dd1a7357f9916a2c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f2b0cccd66c02d509478fcb2da05b4cabc2d4ab41fb07bc35451ab37248408052c6393dc7141c72e2b67b66618bc5aa7"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c198a31f870de9bd0a3650ae282fa30d1e4ebe934c9c09a89990109a94097f268d2591e448e8402feae1c1f50f33df68"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5c9c9d5ef6fa893ffc3c143dd4c3896a5f9ac3f4ee0431282f8569b1e65ba38e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "77d3f5a08b0392852966cd6bb5a5056e880f8112e328e3744ebeec1a97afc87f8756b323cc5a9b04175b3a5548d57da0943dce53c32a66c34e1d6d49ba1cd03c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-aop@6.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-expression@6.2.1?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-expression",
+      "version" : "6.2.1",
+      "description" : "Spring Expression Language (SpEL)",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "cba4fb289daba10c26882d49062e3e6d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "91fcf6b9501705c31c8337e2713fe823bb512b24"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e4efd330d907a506a4ebc558f5ab2f2320a399527474c95316c16d510c9e222e"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "10f3ff52b7d4fbb2081005ca37410570e9a7e62b95a4d988cbd44d993a58b26fa7b04a34df84997bfa11ee66d6bd941cadbd99d5e1281150393af441934f8b9f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "08a129fdd41b7f2e0eabf9667486b2be449d73fde8447018b52b270cbc3209d7a67f2af56212a17eaa9e5793a343f79a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "1803a4431a1ddf35d1019654dff56ec9cff8b21171beab75d919cfd9998a99fc540b68b97b2e2a91764d7d7a38bf6d00"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8fb6f81bf7f7bb8268fb3f06f4270407de6fe8f03bc4b376af5da568e875716a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "214d7b0aecbd5baccfd0c9dfe6f3109e46faefb0201bbd34c94efe4ae18e7e9656f2871fe39202340ef9cf15b708cdc00d38e2706c91ff9b8d9cd7065bd146bd"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-expression@6.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.data/spring-data-rest-webmvc@4.4.1?type=jar",
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.data",
+      "name" : "spring-data-rest-webmvc",
+      "version" : "4.4.1",
+      "description" : "Spring Data REST - WebMVC",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d674f13462e2e1de2c043333a9f79f6d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0f0a836f8fa72a136dd3c0eb9f0d0303f08fec3b"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "07b3767a0135dd65788b766786106c7259a8437901a0fd873e8de0af03987f88"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b740888b68225bb10cd0b4930c800147c488853383c5a6b5447db6ad65174b32bffb941ef77cc157dc0eded8406118ae7d60c1734837c0403c4913f11ea8bbfe"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4e939eb294552bafd5af58e27792bffb561a620c0929198581998d33cc2a74ec26511d72a59dcec9baaf4f187742f59a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7d5cdad9016b5d88d7efadd38ff5dc9d2c6220455785d8c55c38f5934fdcb9b82301dfc48920cac7d09b4ad47402760f"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "2a4096a6bd8325fe916db43b0e2ec9d46c4c54f35a273037598cf1b9b648734c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "47d3274b924bd1a2b15992f4c076fbb586c9a0fbac2ecaa08db200e9ae81b38468dc58dbfcf4fe81a101f5bbe84ded2873ff1b7547255c1b75226ab7a1d802ed"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.data/spring-data-rest-webmvc@4.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.spring.io/spring-data/spring-data-rest-parent/spring-data-rest-webmvc"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-data-build/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-data-build/spring-data-parent/spring-data-rest-parent/spring-data-rest-webmvc"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.data/spring-data-rest-core@4.4.1?type=jar",
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.data",
+      "name" : "spring-data-rest-core",
+      "version" : "4.4.1",
+      "description" : "Spring Data REST - Core",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "32767b693b3a7a3694be302f37ecb073"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "c8bb7fcbdd8013161f6b8060579a19ed7457e7a8"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "598b268ddb8a6c69370a5696be5c05b24ac267429d823f22d806a6308fee61b8"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "909917f8a034c8d61f500e33917cef4e31812e602545cbe80306836b3cf3358be0b28972eced02c46a563c06a854297be5bf9879b8c7e09ea01403f38237e27a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "731e415c9a76fa9bf713c6439253e2f17cf5ab8e007bc948a744e3fffaf53a263a51b01c34e1df30226a3886b7521a83"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "58cf55a5d1a5c2e1a954866edb92f581d31bd2ebde0384b1263b7bcbba170a58cbfbeae185ab423175238b2f8b55d82c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "92cafb8dd91f944d70a20d86d2f388a0a5b95acd303a29d8f1f46a3d34e41967"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "51746441c19559f051c65b1c5f5da9c7d6966c00a13d07c754dcb0d7950ab1d4e50b291eca35dcc3a84fa1489f4d1b11304343bd81b33a974469a7fd9592cb03"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.data/spring-data-rest-core@4.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.spring.io/spring-data/spring-data-rest-parent/spring-data-rest-core"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-data-build/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-data-build/spring-data-parent/spring-data-rest-parent/spring-data-rest-core"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-tx@6.2.1?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-tx",
+      "version" : "6.2.1",
+      "description" : "Spring Transaction",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d38c8016465af5167f9c1a250889a179"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5ffde4fee85ff021ad613b9e86a9be893fb52572"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "388ca8b88a8a8e252973a1491e5de5b85b909cc16e5ac6aa426174f161c23b93"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "751cff1218a362464c70aadba9fc62a69d8a97e7b5ebfec833c6c415336985dee33fe81a80705aa336be9b6b1c8486083d779fcea41136f692098d43b4a3a3f4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "57d8dfce022e4da915fcfd2755a6bcba2192a9c0200d589844766b0033279f0fcf879d7ad719e1e54a538f750d564fd5"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "21c7bd39af76728509b969cec4fc19a6ef03b01c139041b23f8fe1613340a8a6a9da8336e601200ccbad2cddb9afa915"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "43fe94a1fecf7a1a912d4c279fa1bb6f027e5df0e1ca7ed385f20b082da7dc07"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cf71ed5ab9febb13c28b3f8a18ef5cb542a1139f80a02aed1bc43890cf0f7fc35e2c2e3cff56634d449edc8711ddd130fae73c8aa8246ce82aad9099f3f3d8fb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-tx@6.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.hateoas/spring-hateoas@2.4.1?type=jar",
+      "publisher" : "Pivotal, Inc.",
+      "group" : "org.springframework.hateoas",
+      "name" : "spring-hateoas",
+      "version" : "2.4.1",
+      "description" : "Library to support implementing representations for hyper-text driven REST web services.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "26c2ec5acfd226270424f68de562d8b4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "86a69fe432361c0697aff89b4c8f293edffca26d"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "20433db64218c49512a7197a6a15fec2fa6bf056bf21bf6a0af81a5faef997fc"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "613ce7b4a7e3da3e68d25ef4218d8839900dbfc01f81388e1c62df9c0cb37610931300536b51342c43c0a483b5ed7a7f77347c0115272a86bd6e40751cb430ca"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "96c11a4a25f2c1ff3d6ffdda285d3a813a29d2349b038d8b400335c5d2b24699410b3093fa9a3f0c70540478005d0d42"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "d8cd227d3a8ac4c91c53a566bad2c3d3e9736f8e28fc79a12b9ff1c3a81c87ab54be44e65908eee0b0f2b27b6860cb87"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "27e529125cf8414ddac99d8b057ae35b2cc8b4e2194513041e5e2cf101b9fdc8"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "f2d3a491fdb222dffe280d6997ba89090e431dfeab0047a263290fcc469e68da840942f8f34a3e10399ad7fe08006c29c6bb1c15ad0c2a28c9d27afde6397fb6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.hateoas/spring-hateoas@2.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-hateoas"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-hateoas"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.data/spring-data-commons@3.4.1?type=jar",
+      "publisher" : "Pivotal Software, Inc.",
+      "group" : "org.springframework.data",
+      "name" : "spring-data-commons",
+      "version" : "3.4.1",
+      "description" : "Core Spring concepts underpinning every Spring Data module.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "be67d44ddf59628bc5bc66d00fdfaf65"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3ae5f19bc2b1b30de85b0610ae25818c2e7c295a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8497fdf6952394836e714f00898f429a3a5159fcc9d319636eff987b5c22c662"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "67e0a08e9744c734e58025e9e450ad2c1913509c5262bb21d1e69346ad5187ce1ab9d1d64ac3dc952d0b74409ff3e92726182c1ac94f03690167c7b614705f88"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "588651525b51cd9aa9f9030b54335fc2a6d48fae56ad80b1b4f9c59a5849c9130358d272bcfa30d6caea0970756a0ca6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2a85cb1634bcd7b23704b4a076f4b25e1a3b8606d6c001e89198abff59f515e719d7a5265188d80b32607f6f9b81983d"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "aee838985be99ae6d57c53cf8b4082707047e022d181a3799d451049a9fd5157"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "9f151a9ee20386a5f959e2f5a709552937bae30b41f1d54287cc65c7e66af5c1672cf0e22a77b291309c1044c189d6e91cde8c916e16c05becd721ca2a84b388"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.data/spring-data-commons@3.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-data"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-data-commons/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-data-commons"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.plugin/spring-plugin-core@3.0.0?type=jar",
+      "publisher" : "VMware, Inc.",
+      "group" : "org.springframework.plugin",
+      "name" : "spring-plugin-core",
+      "version" : "3.0.0",
+      "description" : "Core plugin infrastructure",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d29a8f831dfe90d150ab694489f2e7c2"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "d56aa02dd7272dca30aa598dc8b72e823227046a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "edf72d44b9cf1199cc783d620f5f86df82fb378521dac313540086e6c3c66ff0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d423678722df2b68d42bad8fcfc6f4bdc8c1c57a2d1d2e007123d91b3903f112a6692b92a856261a0f78cbef8c297c94416b2664e7166f5842ee8313d5c0b223"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "f4ab270aa01c2c939802948b64a7e8a48c28c6b8b19c13a3545d5ad1806f6ae52219af195b503a8ec516f30833761f8d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fe1ffbbe078cdf51b12b67304e3cc0e01ad0e5f6c7a2f5612a4e2f5ca6d9469ceef9d111459e0ff0c679225c33fc47e5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "31e78fab989977adb321cb787678f2cd2323fb13cd979611e62b42bf847d20dd"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "dbd3b2ecae73324539c062195189319bdaf812d7ca94ebcb21061a46da5b214a67907a0db3b2fefdd789ddd92205a8c2328c03842465e46e484932f6f370c6eb"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.plugin/spring-plugin-core@3.0.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-plugin/spring-plugin-core"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://build.springsource.org/browse/PLUGIN-MASTER"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-plugin/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-plugin/spring-plugin-core"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.atteo/evo-inflector@1.3?type=jar",
+      "publisher" : "Atteo",
+      "group" : "org.atteo",
+      "name" : "evo-inflector",
+      "version" : "1.3",
+      "description" : "Evo Inflector implements English pluralization algorithm.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3ef7ac615df62834f49f2c29c57fe329"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4cf8b5f363c60e63f8b7688ac053590460f2768e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ac0192fd110a0363732b17ea94fd1ce8cfd85790c8e1551e14f866908b5d80e1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1de8b7a1051cb8bd2bf46856e7cc16462c7d0e5e05103832504dcacde9f19e67ad655871174b91028fb1700eddd1ce4485845bf587824860cdc4350b27cb2608"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "53ea540a37bc353b2e332771d86eae070c71e9ce0d1e7f15106fc4c541bb9462eac539cac28412967a7719f5d1c97916"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "457cde7e239e4040aa770fba7e354b0cc385e83bbf07099b15f7dd8a03714cc8dc48bb92bbbc7b664dff00d57263361e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "21db4b40e66330b946433e3147e380f05458c3614f48fc92c28114a2560fe3eb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e193c431019992f3484d30dc8c2401be42c89f6a3b1a69379f1f58a5bf7069ed90eec30e515a292dbd1660a6dda6958fa0f8e7a0fea1be8cb3981dc23ed1b43c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.atteo/evo-inflector@1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://atteo.org/static/evo-inflector"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/atteo/evo-inflector"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter@3.4.1?type=jar",
+      "publisher" : "VMware, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter",
+      "version" : "3.4.1",
+      "description" : "Core starter, including auto-configuration support, logging and YAML",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "56b53e331476cb78cd719666f96dbf4b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2c97b6fdc451ea69cd04dcfa54980439b7c7cb34"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e095d43127dbc507f49119d43b7cecb0977257855d5eed989f3905acc897d9cb"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "47277f3e571159dea7c5036f6d5047016cf74bfd386f1cea3281213341477cd5797ad417f342a1a77ecadc69a80cd44c84656e0fa4c80b9ed3f6b4de792573db"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "0500e3d562adb5f3a3164fcad5442c8e880959c995e670a364fc30e73be8d67c4bf68ac27298c97a72e35c6fd0414047"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6b361d0875aee6c19119b28b02c3e9152479719914adc686c6b0bb8d220a4bbc708237f5e04c47323381eba4f7f1ebfb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7dfb55589ff2fc5699bcdd25b86c27197d2bf4cc4c2e19f46c349b302ed0b5df"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "afcf7294deb6eaf82220871dcf1c4b6db12b23c13bca77a4dcf62e6dbb4b967656b233e4af917b95e0ce4a9f4523fb8f34f215db53bd8ef4717f88ccdfb408a7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter@3.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot@3.4.1?type=jar",
+      "publisher" : "VMware, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot",
+      "version" : "3.4.1",
+      "description" : "Spring Boot",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4f7d4f6624312c1ae78bb8a1dd208c80"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5fb9890a5eb7c4e86c8f5c0f6960b79240daf3d5"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3dffc999ac8eee6b51e8eb9a73c9f29f2a28b7f0f359d45b89aea486268190fa"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "06b0a25cb5b5e51e0234d7728e49a9172f077f572ff746e08ce7948c4bb4929129622094031d7d00956af4b11565e4aae324ea2af98ecdd039974d281ac7cefe"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e210fd632d60267ef975e3772b651172ad9720f65be21aba115df8d3f6d1294a902126e204d8bfb0fd695dc2d563aa7f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "33c034104fecca128a6173c98e31682a4398acbab2a23b51438ae2907f63fa4fe891cbe50d4f2750d3e03d526b2662af"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "462593b919093bfd7217f921129f27cbff7afb851d3234e7836f1aba653dc8b3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0552c4ec7992f9ca7a1d5a8be9051f1e079c5fcd82225bc4f6195de676781acea83fb9a42d3ed1d5dd78492a4e5cb4eda45137957664ad5ec665a7a03a2e86f0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot@3.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-context@6.2.1?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-context",
+      "version" : "6.2.1",
+      "description" : "Spring Context",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6c650372cd5aef72f5cd4eea1194ef60"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f56c7431b03860bfdb016e68f484c5c35531ef2e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "226617237451b420f5742517d1aaa27fb20bb3dbe23db6fb5ea1570bf97ce162"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1c5cca27dd892ce641f0600ec1cf9c41865f7b33794da86232fb1f35c334cd33ab0e36de0c62824073b3f06b60e72cd5819ec26f15f9d585c1ccfee03c2f5fc3"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "270faf9a15c4dea48a7d8ef0ccd25af96ed3e969f76e95c480f55aabbfab5ea5db8708f9ce89af70e8e15afd37e1e31e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9a3fc104b5a42888ef0df1bb0b4314b26ce696fdd1989c74a945e8977e8a6483dc1a238fbe397e9d81b69a49beff1c10"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6869e190d63fd7e7c776ac4ccf7ea621ba91197e2ed2b45bad6427156c6ce12c"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5b932af39544d06f78e4b9489880e5941970be186aaadb96d49e4ac38748a29f44b5c3ba16259618484a767685b46ab93c39f8303144e7490be32f3a3de5d345"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-context@6.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@3.4.1?type=jar",
+      "publisher" : "VMware, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-autoconfigure",
+      "version" : "3.4.1",
+      "description" : "Spring Boot AutoConfigure",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6e083185619b2dd1fe6dd0b60147f599"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f17b54cc5816ec8f06d0aca9df11c330ead97f2a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "dc68c9d977455fb23232cf0771a9079b9e44e246acdc62d872d8acd45edf4783"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "fc818069d937ed5d9367535759041a454f8fca3344c7f73664a2c591efb6cdca27a6c22bf5252d05bd1d2080d441dc5cd4e20ffcf4dc6639e0569291b9fc688f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "45367da8e9b585f974828d74b94b3c36001e2c719d79c7ef4ea6d5ef5af47ecfd211a546f562a221eb242c883b09bea1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "0b2304f1fdd01c1c7ec2e2c2d30adf918153011c0bf4f2067c79bcba48ef1c52b74de523680b73bafe898038681c74d5"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "de03ad4fd72bf09656fab66456ba330d47d7a1664003efab143e732fd8d249b1"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "cf817a4ca726423afea831a60f1e462f5b8bf324860543326a88ab07e5c77c114e3aa6a75b7ab07212f44c403d87f77e91fde38c871fcd3064014d0758e027d2"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@3.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-logging@3.4.1?type=jar",
+      "publisher" : "VMware, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter-logging",
+      "version" : "3.4.1",
+      "description" : "Starter for logging using Logback. Default logging starter",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "aff6dc47456162415ad41396be9904bf"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "5cd01e208b15113c7f88b3ea40e843ea9989f38a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3a2b5aa454fa876e08273c8437d340aa24518f774e1c2f2bf8b5970259f2e604"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "56f6235ec1cd2c504272b1c8536992c7569e32e762756bf0f30bb7b042705bc25e7c109ef89fe93255bdb267fa771cbd9d692c8d0a54af43d6acc5c09e83b792"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "11d5452dd0a232226615cc81d7098554474009d721c74a14e60209fcdc008b1588d253c7d506f7d21b3bdde12734449c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "664abcfc22163c9920b14ef082d9cc11abc4f6fe93474e6c7d45e5e09a4a07d6448b7847be68ca39ebbafefbfb32314c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "b85d13d618579b8756a965c6858ee3ea846d85fdbdf86167eb1d71579fbe443f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "963e90912a156717d584dab7e46287e291f3905be23bcafaf3211933102e035c73851d1d4e00c4e04158b8511d125a396a2ac6261ff5853517e2e429ca84ed12"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter-logging@3.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.qos.logback/logback-classic@1.5.12?type=jar",
+      "publisher" : "QOS.ch",
+      "group" : "ch.qos.logback",
+      "name" : "logback-classic",
+      "version" : "1.5.12",
+      "description" : "logback-classic module",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5f752b29e5cf40b79a5bedef12cee8c3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "3790d1a62e868f7915776dfb392bd9a29ce8d954"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ebe1a2ce1072b365090d58af40fcb7482d7864a31cd2b1c62c9b1d13f9a80c09"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "aed701822944b656c887b21106c1643f5af45545603896405cc985422707450c5b4ab3c3c97679a6e9b2ff3147e5c4a5a4f8e6ae0e064ded39f50a78bd8cd9dd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "09d8ed691771d85117fa5f6b16f45615d631c193f119c5f91cf9d0e14b79a6a926d5faa244b3b05e9364e1100651364c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "2ca710e4c9eadb5f1724ad5382414589f58eda9dbeeead66775f9517646e7563e011fbb5b4c717a5281cda87bd549899"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "39e835f6d34caf4588bfb014afdf9922b3a5f39a978c497868aad407fc01ba7d"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "398a1b92978bdc78efb781fcdc6d9200041a523dcb466eae08dc89157431b30fb41408137ad5c3e0e6f557f9667f03e34074a15574ca16fe0edb4c1aea1089d9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License",
+            "url" : "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.qos.logback/logback-classic@1.5.12?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://logback.qos.ch/logback-classic"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/logback/logback-classic"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/ch.qos.logback/logback-core@1.5.12?type=jar",
+      "publisher" : "QOS.ch",
+      "group" : "ch.qos.logback",
+      "name" : "logback-core",
+      "version" : "1.5.12",
+      "description" : "logback-core module",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e381425e2c7eb1b0b0f3fa93f6c67355"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "65b1fa25fe8d8e4bdc140e79eb67ac6741f775e2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3f35b41621c2cbf72a9d9f3ce2270ba2040e4808bd6befdd720866e926d3e84a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8ad1ee4e0451f7b2e96f0930928f80a3f2e7b570affef9373d80417cf8059bc50b12326586a4b3feb9ad32522a19978c59fb3865ce0f675e03b1c496907f26f4"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1f82863a738c4c732589df40852358e375f8f6d64460a1d668b5113df2840ac3e5ecaed073b92b0670cf548dbb3914f8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "50dced8ef199c13dae3538b7ed6434ae852365597b36d7e31954984f13880b44117266aabadcd4cea478bce216235a9e"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "654d87e7ad22b9c0b8dcd10806efc3a308b9b270bea2274c51991c60931b71a7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b9db12e0251b77ee6ab06a0b5a23e217ec16efdd09f7d683f162b764a6facbb2f33e0e7f8493090e027849add0d8d802ff49d132d4d88a9ea2c856414220572d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-1.0"
+          }
+        },
+        {
+          "license" : {
+            "name" : "GNU Lesser General Public License",
+            "url" : "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/ch.qos.logback/logback-core@1.5.12?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://logback.qos.ch/logback-core"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/logback/logback-core"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.24.3?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.logging.log4j",
+      "name" : "log4j-to-slf4j",
+      "version" : "2.24.3",
+      "description" : "Forwards the Log4j API calls to SLF4J. (Refer to the `log4j-slf4j[2]-impl` artifacts for forwarding SLF4J to the Log4j API.)",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1f4b63f9c41f2f5179aa10b35d76e805"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "da1143e2a2531ee1c2d90baa98eb50a28a39d5a7"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c7f2b0c612a4eb05b1587d1c880eb4cf5f4f53850676a8ede8da2b8fabb4f73f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8ca27fa34d4a8a6e57c9f578c85769a685659d34dd00a855d65f22ebc936155eac1c76aa4bf4f439e302e9a202f9c0856df01e543259bd9d2675ab59c20b6f9b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9078afac573cf6ae3b4d548a933ffebe5113ba74438cc4db75135c45f35594079fb85b698521227a61dd464a3652fa8c"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "65b28474ade17f1b34da33d6197f54571f598fa4535c49c0f41ba807d559045ff4d41140a55b0b5f4103cfa965daa237"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "dade25cfd6470dfc19cf2006073b7838c543b10ccee5b86c6d459461377e7a0b"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d39e348fa249075eecee78ce17d4be794d3dfd9d07ab9c9e90a5981139836318d48d3c46146ec197e561869d7af19ae36de9b172272f878242c97a02f68620ee"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.24.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://logging.apache.org/log4j/2.x/log4j/log4j-to-slf4j/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/logging-log4j2/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://logging.apache.org/download.html"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/apache/logging-log4j2/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?log4j-user@logging.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/logging-log4j2"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.24.3?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.logging.log4j",
+      "name" : "log4j-api",
+      "version" : "2.24.3",
+      "description" : "The logging API of the Log4j project. Library and application code can log through this API. It contains a simple built-in implementation (`SimpleLogger`) for trivial use cases. Production applications are recommended to use Log4j API in combination with a fully-fledged implementation, such as Log4j Core.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d89516699543c5c21be87ee1760695f3"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b02c125db8b6d295adf72ae6e71af5d83bce2370"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5b4a0a0cd0e751ded431c162442bdbdd53328d1f8bb2bae5fc1bbeee0f66d80f"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "d936ac37b3d7ca2e4370ef122629c5ceb0bef60a6c08a3bd8bb278204dbed84bb888aaa307c58e80e4e9d645b73792433f52adcccd30378fbac99b1d271042f7"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d376ab3673186a1a39ea8b3d3c8359bb16dbb3f5d3782c182a112ab19b61d7730434c6d0f631d43d6daae66005d1df4e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7ee1b17a329d90bf648d05defced8d79f7bfbca66cc7e90aa2e1b2d7622697d535969e50d1a03460447eda2fa008f86c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "5d2ad18a3352c3d7269ecb8d52d6a5ac8bf0d0d937e4809f5023a45d0f8f50f3"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7e964e6425a1198e2568a9e8c326f730b7d139f71e8d3b1b440aa90860f136f443e5ebd62aa022c1c7834e23995ed0992f68dfb1760140d469b85fed84815ae1"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.24.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://logging.apache.org/log4j/2.x/log4j/log4j-api/"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/apache/logging-log4j2/actions"
+        },
+        {
+          "type" : "distribution",
+          "url" : "https://logging.apache.org/download.html"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/apache/logging-log4j2/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?log4j-user@logging.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/logging-log4j2"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/jul-to-slf4j@2.0.16?type=jar",
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "jul-to-slf4j",
+      "version" : "2.0.16",
+      "description" : "JUL to SLF4J bridge",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "410ad2f2230e0150216d86e12a4af995"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6d57da3e961daac65bcca0dd3def6cd11e48a24a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0f2ec396ea29c9a440890d1f09fdb82fdd574b47b298435764235451c193861d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "0c4c1f62bdaa29e7b6fb41fdd62e398fb92e74e64ab36788be930468947ec94821e97cbc820159ec792f9be4cd3840ce60731be2c7437a734a458cbd2e412184"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3216d143cb8efa77b87e54dc4f9e77f256b21d1c9525f45a26177a7ad264c32d229cf65bf67cf4bcab546663f41e95f4"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8c551dfa80d6dc591b6376024362884625f259c8ddc4258190386e90a7b2141b40e2ed42b4ab6be93cbb1d81bbf0ffc9"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "ec1e9fbe3de9345a41059a3f45486a24948fc041d86e5455106b06501a6a254e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "e5912c03ec7a44feae7aff8d56221572be431a1c1b08407090d4187d64c4c8c2fd25f6d4d441005f95410637377f3c0fdee683c86d83a3c78918b3b84267caaf"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/license/mit/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/jul-to-slf4j@2.0.16?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.slf4j.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j/slf4j-parent/jul-to-slf4j"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@2.1.1?type=jar",
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.annotation",
+      "name" : "jakarta.annotation-api",
+      "version" : "2.1.1",
+      "description" : "Jakarta Annotations API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "5dac2f68e8288d0add4dc92cb161711d"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "48b9bda22b091b1f48b13af03fe36db3be6e1ae3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "5f65fdaf424eee2b55e1d882ba9bb376be93fb09b37b808be6e22e8851c909fe"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "eabe8b855b735663684052ec4cc357cc737936fa57cebf144eb09f70b3b6c600db7fa6f1c93a4f36c5994b1b37dad2dfcec87a41448872e69552accfd7f52af6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "798597a6b80b423844d70609c54b00d725a357031888da7e5c3efd3914d1770be69aa7135de13ddb89a4420a5550e35b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "9629b8ca82f61674f5573723bbb3c137060e1442062eb52fa9c90fc8f57ea7d836eb2fb765d160ec8bf300bcb6b820be"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f71ffc2a2c2bd1a00dfc00c4be67dbe5f374078bd50d5b24c0b29fbcc6634ecb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "aa4e29025a55878db6edb0d984bd3a0633f3af03fa69e1d26c97c87c6d29339714003c96e29ff0a977132ce9c2729d0e27e36e9e245a7488266138239bdba15e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "EPL-2.0"
+          }
+        },
+        {
+          "license" : {
+            "id" : "GPL-2.0-with-classpath-exception"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@2.1.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://projects.eclipse.org/projects/ee4j.ca"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/ca-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/common-annotations-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-core@6.2.1?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-core",
+      "version" : "6.2.1",
+      "description" : "Spring Core",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "394df39af63d06af987c5629c15c3154"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "f42e6b51d9c0c2fcf95df9e5848470d173adc9af"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "67f0e17811dc8d5d6c3aed5540afaee02c83e3a8b3f9abbc510d4d95db5cc226"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "c4d9cb2651f95426067ce794de861b856b328a99e9a6a5f679b1c232afbde336ac82163a17c09e103756bc2494456b95b3d07040300f30e40ea0c55b8a23a9ba"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "631bc8df95778e2287099e09250faecb685ef9709a4ba28e35921fc48deb4887accd51ead50ef2d6e78cd3600eae52ec"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "124dac013c9626c9d6e88bc367027ce84b4be94c3678018170f388f3c4592d823c3ac7d52232b7a9a3aa30fe8cecc617"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "0e43739b6b714f60e692aa7f4e409f02c2381a9fbc522aa5b2fe34ad272f70a6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "0a20c20a516def1f85921410313b7a5518e03c2a26384cad83c836a411462551252dcc6b83cb24fbc30245404105012eac5d0cb6df2a9eb8aca61eef7492fa87"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-core@6.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework/spring-jcl@6.2.1?type=jar",
+      "publisher" : "Spring IO",
+      "group" : "org.springframework",
+      "name" : "spring-jcl",
+      "version" : "6.2.1",
+      "description" : "Spring Commons Logging Bridge",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0580c8806b325bd0fcc984ae7a5e8b45"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a5d662d64470aff0ae51d210147bb6ede31a8ea3"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "83604b743df124b064836bc930d7e7c8e81832144b9e4292e7b816fca0cd42cd"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "64cf62201bc7cf80d13be7627a4de7bb2c2d4233287a88abc4e5300d7eb952633def92c3ebb1435390af1425e5216579368ef1cd21447a85f398c7d4f1b5de1d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8dc74ec4559d1335c29f8d24f57eb75b4d05390ecb8574d3e633f9c18a86020cfa6deefd150352968422d950aed860b1"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "654246ed831365f018c3eeae112ebff54ad86400d1450f3e57c51f8378b0a80266542726bf5886a5c669321499f97a51"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "fd4b98c4f24e0a34941d8ba820d6c9b0c4f073e488a110860c147356286faae0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "27b0663d30741188bbee608504c9de9ed3068f20414b76ce05029afd170ab6770171ae3f68761a7ae693eb7d675ce93d61915f8780cfa21f80289e94918ad1ec"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springframework/spring-jcl@6.2.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-framework/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-framework"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.yaml/snakeyaml@2.3?type=jar",
+      "group" : "org.yaml",
+      "name" : "snakeyaml",
+      "version" : "2.3",
+      "description" : "YAML 1.1 parser and emitter for Java",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "2a1c2ee8923dcd6bd6d025751af5df37"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "936b36210e27320f920536f695cf1af210c44586"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "63a76fe66b652360bd4c2c107e6f0258daa7d4bb492008ba8c26fcd230ff9146"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "1c9c78f0d102ae49a7c06f9e20c6a79a4fb9a2af962230ee6e136bda0caf10dcbb9deadc1c3ab15f74a4982ec8f8266217115e357329fde5b3f4f1858882de0c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "77b1d06e83fd51b83b13372d5ef2eb43c5a66f193db857cee947ae4e900e4a4a0c66a8074435984b9a0b007a69cc2b4f"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "550c4e7a119fd690f750317dc0e20ad7bfc7fa28fa0409fc572bc745d51340a60e9e2ce2af97f458daa561155130bb97"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "d1b540ee39c34ab1484be27d2dd56a14aa48f88668905f9ad176932f4b2cd5d6"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "879ccb34343ebd4ac4888091d97f393c5f75cbb066cf8cf1b9b3eb03a3442cb17326c60bd0db1403aa66ed1f0a5a0d548c96dbce74ebc5c3d6d93950f24b417f"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.yaml/snakeyaml@2.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/src"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents.client5/httpclient5@5.4.1?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents.client5",
+      "name" : "httpclient5",
+      "version" : "5.4.1",
+      "description" : "Apache HttpComponents Client",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a114dfe3b3e460e2a209c01961ed7709"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "ce913081e592ee8eeee35c4e577d7dce13cba7a4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "c6c6fc60cbb3edd9e823d9226d608ff3135eb48bd2049bb83bdbc3ef4a911138"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "00125c1bb25a00b3a21bbcf77a555ada9c84814af01c3fa350e25fc3af1546e0699abb50ecc7a1e646c1572ca43a4165905c5c4bf8f763df8aeb29c001f78334"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "85ef2e6d2c901e47338a9eeb23cd6254feb9bb70abc9578a9e9a95f3c84162fb3049145e4a01017e2e80b2060111cde8"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "555d404c69d4e8d8d197f38b12c72a77bda672776dd87712a5e971cf09002b4c12c8f4eb91caaac0ae575d6a7ddcf0fc"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "791d2f80934ecabd4696f8e7d781ff2e0f502e35c38e7dade4f760bfcd46b082"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "da08f04f7d3570d067498abb3a3313b24bfb5b4e4e60c7dded17276deada5049f2d4404ff9d72cfd1bc5376713564957977c0ffd0a72b9180d167bfd0320f8ab"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents.client5/httpclient5@5.4.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://hc.apache.org/httpcomponents-client-5.4.x/5.4.1/httpclient5/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/HTTPCLIENT"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?httpclient-users@hc.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/httpcomponents-client/tree/5.4.1/httpclient5"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents.core5/httpcore5@5.3.1?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents.core5",
+      "name" : "httpcore5",
+      "version" : "5.3.1",
+      "description" : "Apache HttpComponents HTTP/1.1 core components",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "730f62c1bf2637c200d8d133d0b1247f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "eaf64237945d7d0f301d48420e8bdb7f565a7b0e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "83f559ad1ee723c1ab3e80b040551cfacb2e5a52bdf04dcdd35419a6760d81b3"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "52688f156375d083f8571c8c8733ac74452307b7f49be513dab758bfd888aad74c37e022450e4b9fe67cf8b49199ae45aa1088dcee48e050ebbd47f6fbabf799"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "94dfedb0fac449228b86395a1163c5317355e05a151c7d10b589d387cf50f9168617d2c325ee528acabc537f0139dff9"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8c265c318cda49efd807e0910773061ab2cec97827f3419bf261bec2dc62431dac38282172a4e9d70eac17d0f1db2a4c"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c85ed6ece5d079710e2a22ca6754998de0f501331074401a4a68eb2712266028"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "07a60318d9cdecb811ff494b9ed9c16c094c358de28b1d75f2dde77a721a4319917fee590bb93d354fdce52d39ec0a25db5d4af8c369f31e1fbf89f0486fa24c"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents.core5/httpcore5@5.3.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://hc.apache.org/httpcomponents-core-5.3.x/5.3.1/httpcore5/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/HTTPCORE"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?httpclient-users@hc.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/httpcomponents-core/tree/5.3.1/httpcore5"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.apache.httpcomponents.core5/httpcore5-h2@5.3.1?type=jar",
+      "publisher" : "The Apache Software Foundation",
+      "group" : "org.apache.httpcomponents.core5",
+      "name" : "httpcore5-h2",
+      "version" : "5.3.1",
+      "description" : "Apache HttpComponents HTTP/2 Core Components",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "4cf50639992f2796200049e778ac64ed"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "760c34db3ba41b0ffa07e956bc308d3a12356915"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "963e194a972aa3daf09287c921ed5a2dd4c3985c44185b0138002943025bed6a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "cd8f75113c419477d640550643646778af863254e26225dc4ff5e8b1e3ab59ca52495505bfe4bf8735ca6ec5f571620bf53203bffddb176791c14b7f5ed97d76"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8c5db09b1e9c26ff4e9eb31b590e116afba000e2d96a0d4d7efe4e274c8ce056eeebc3a60d4996bdf7d597a303638e09"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "85117ec342bbd322ed4483b58780cee0a54fb392bd14f46cbc7f2de89e7f878bfef8bba06a241eec46a9a10a8faf515a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "f0fd290266eec9968a962e3f3834bae9d31a636b77468065fcdab78e27fcb23f"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "178d26cc9f55940c2de8af3df712ff23417bf80908843d27fb4c9a33ca5105b3e3da15fcda7455147d0639861ec8053827e9ab6cebd0320fdbc15b63aae28ae9"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.apache.httpcomponents.core5/httpcore5-h2@5.3.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://hc.apache.org/httpcomponents-core-5.3.x/5.3.1/httpcore5-h2/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.apache.org/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://issues.apache.org/jira/browse/HTTPCORE"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://lists.apache.org/list.html?httpclient-users@hc.apache.org"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/apache/httpcomponents-core/tree/5.3.1/httpcore5-h2"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar",
+      "publisher" : "QOS.ch",
+      "group" : "org.slf4j",
+      "name" : "slf4j-api",
+      "version" : "2.0.16",
+      "description" : "The slf4j API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c8de8f5d740584cb24b5652cfba8b3c4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "0172931663a09a1fa515567af5fbef00897d3c04"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a12578dde1ba00bd9b816d388a0b879928d00bab3c83c240f7013bf4196c579a"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "91c2e7b30f24649bb3edfc7f138c2b7dc715ad36963af159defb80a71205eb7e4c5bcc80d779ef993b567a56724064f190c93985f32665a8df85198a03a2f1bb"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ed0cc7ad67343b9fe4df03ea534025bf9d90c112b33cd8920f29890d923c349b69820c9c42b9e8882047af848b74f99d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "331ac707cfa4b2bda44deffce7d2a640abb9ae12968cb1ac4879ba1b45542e3d3ce1016c812ff1f2449336bc7ea6bebb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3f68204951bb4baedc34fdd7194d0801042268aba0c58ac5d760779510743fbb"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d7a2f7359e7b2cd6ae3650d28352bf8789acf5855a3596a3be2a236a94931abf8bacf0d6a457afa43164be53abb19cc223ef4f030822a3295c036c078527e361"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/license/mit/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.slf4j.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/qos-ch/slf4j/slf4j-parent/slf4j-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/com.jayway.jsonpath/json-path@2.9.0?type=jar",
+      "group" : "com.jayway.jsonpath",
+      "name" : "json-path",
+      "version" : "2.9.0",
+      "description" : "A library to query and verify JSON",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e89678d2e4ff45e4f39a97ccd0223719"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "37fe2217f577b0b68b18e62c4d17a8858ecf9b69"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "11a9ee6f88bb31f1450108d1cf6441377dec84aca075eb6bb2343be157575bea"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "9a9dbb2cd36662c8049419ed891290602baeca2549eb7df62122cb20c91e66bc8c2c0e5e13199c4a70bf0b6e62ea4c2601f84e4c79d2af25ff1704481c86740a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "e9a54630e2111078c8c77807d9f4433e2f459fb6c41c4afa8c2a3152b62c240ea9be1614022a6a99d5aea8c61865ecfb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "64286f27125cd6fcc3a16c0b4be106686aef7744ae103bd2160ccca622547653b9fb44e10bc6d510d16b875c95806a10"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "96e06e77b263cd1a3adb8d9c6fa666d11eebab616c4a7fb2ef7f370039a0a4ea"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "10bda57556f6ef77669f9c99fda226ff5060d3c1511e561d9e7a49fc2a534b90bc4101ab0e4ef0b420fe43f71083bba1b64ba606348e87459a6183f1d3f7e3df"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/com.jayway.jsonpath/json-path@2.9.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/jayway/JsonPath"
+        },
+        {
+          "type" : "vcs",
+          "url" : "scm:git:git://github.com/jayway/JsonPath.git"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@4.0.2?type=jar",
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.xml.bind",
+      "name" : "jakarta.xml.bind-api",
+      "version" : "4.0.2",
+      "description" : "Jakarta XML Binding API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "0c8f9991081def819435c3ff36e4d93f"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6cd5a999b834b63238005b7144136379dc36cad2"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "0d6bcfe47763e85047acf7c398336dc84ff85ebcad0a7cb6f3b9d3e981245406"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2e57ce867ae3592959243ab9d7d064b09d9587933c98f89f5d5eeb8fe70556a53fea6db91520a2e086555684e8917f4001741bd8ffb07d26c59fe95c13d71fa0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "7ac5da337fccfa426b48691febed0d874a8e9a6a230bb7a53169f902e5b499778106f7b710afbe133dbd7bfacca693a0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "fc952425a51459a5d18dc7b6315625c55889e1b92e700450c84205506e5107ca4c7c8bc449190220bf471db3dcbf9c8a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "a78dd7c5883b16cf899495930e653650005c71b4d9b509e56cac4665778d715e"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "bdf9db79b8ade9421c3f5fc497ebe13a552be5852d99cedfa38bb6c760c8bf190f88204ab6e02442db5fb24378afc6112297c5a582d4e721de71285405a6429d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@4.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/jakartaee/jaxb-api/jakarta.xml.bind-api"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/jakartaee/jaxb-api/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jaxb-dev"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jakartaee/jaxb-api.git/jakarta.xml.bind-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.activation/jakarta.activation-api@2.1.3?type=jar",
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.activation",
+      "name" : "jakarta.activation-api",
+      "version" : "2.1.3",
+      "description" : "Jakarta Activation API 2.1 Specification",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "76e7b680375ea9f40f3ddbd702efcd25"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "fa165bd70cda600368eee31555222776a46b881f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "01b176d718a169263e78290691fc479977186bcc6b333487325084d6586f4627"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "aaabd4d6085a07035eaaae7b5a81aef429fea76e7fe1c8d29971e6595f0adad6bcf1088cff8a1c8936d739b0e3fce4b845323032f046b7edab2eaebd0e10a2ad"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4c4e73f59bf09342ca7691fd4855b41d3466da80618a5b7df059a2d89cf6d9779a4af751a6c4a9c48e5025c3ff75f42e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "20be816700c87778e9453d41b6d8cb9dc992a092a308a9b7f2dfbf72e2393940a7d666c46625f130a2b57bc414df85ca"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "8a574b0a249842ea1b397d4cdef9b6d00b34ce8a849ea34184cdf45ac5aafe67"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "69cfb7dddda70ac1fca272ace0a3d5551b85dd60a6dbaf987ee777fbf573b420d13f06b8990ae70e8fe063f92b78c8a447cf9309ba516a5e993ba2d49cca8d23"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.activation/jakarta.activation-api@2.1.3?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/jakartaee/jaf-api"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/jakartaee/jaf-api/issues/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jakartaee/jaf-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.minidev/json-smart@2.5.1?type=jar",
+      "publisher" : "Chemouni Uriel",
+      "group" : "net.minidev",
+      "name" : "json-smart",
+      "version" : "2.5.1",
+      "description" : "JSON (JavaScript Object Notation) is a lightweight data-interchange format. It is easy for humans to read and write. It is easy for machines to parse and generate. It is based on a subset of the JavaScript Programming Language, Standard ECMA-262 3rd Edition - December 1999. JSON is a text format that is completely language independent but uses conventions that are familiar to programmers of the C-family of languages, including C, C++, C#, Java, JavaScript, Perl, Python, and many others. These properties make JSON an ideal data-interchange language.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "88a65001b616c2e7796f9263ad97bbf1"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4c11d2808d009132dfbbf947ebf37de6bf266c8e"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "86c0c189581b79b57b0719f443a724e9f628ffbb9eef645cf79194f5973a1001"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "a7ead3758b105b2750ce7a19865799232a177a3373ed1e72c553c98955ca911c2d8224fedb0261099b506d5b2c5c203e2edabf24f8eb4aab75c0522affac366d"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9464cc76829a212caab314c0ec23ddb738e516f42c7ef345a5d507bea363d7f655c3fbf70287aee5e1241ba770cd91bb"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "48e1f7eaafc02c3bc644374d23613487d617d5723a892f93ce1305cd2b22931afdf0b9ecd693055ae7c4ecba61c9a08a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "541e3245c19bf583ca53e606fa309d9cadea5192543cd155c471b4e9aefdf158"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "44ed703a3c31d43feb4d767039e6d0412769ff121d26c1f06973286d59ceb2f90502db08117390baf7f64980f8210fcfb981230b026c3938f88bc0b82ddb79ad"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.minidev/json-smart@2.5.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://urielch.github.io/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netplex/json-smart-v2"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/net.minidev/accessors-smart@2.5.1?type=jar",
+      "publisher" : "Chemouni Uriel",
+      "group" : "net.minidev",
+      "name" : "accessors-smart",
+      "version" : "2.5.1",
+      "description" : "Java reflect give poor performance on getter setter an constructor calls, accessors-smart use ASM to speed up those calls.",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "51e60dbf9ac51f6666f0077317990944"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "19b820261eb2e7de7d5bde11d1c06e4501dd7e5f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2796ae857d0c7be4bc3580daa4d3828d555212355f4c83d38dd0af0742b3c812"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "01db07e67d7902726739f83606df4fd99945682486903a8f27079d2e15b2d79059af209ae19287e10b62d54d2763f4fcaf90478d402957a4f76c90db31bf466a"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "a3d613de87fc94ddd60cfb7244ecbc300ac48f1f39d5a5f714f17b057e745f2bffa42089fff71b99ab60ceb73b022b2e"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "126995f1c9f490f71ad455992ca75ea41c97ba94787a2f568ca95f4dc4ae13a55c9a39c7bff071d8ce1b5860248e8de0"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "6b3f28824a6ba164fc9446128dcad927928e83f7ee13c7ad8aaf8d7fed89f389"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "7851f5e83d5a65a859080f099147bb5f5da6227a4c778b094a88041f844cfd49e151c28808bf6606720c18f41698e321dc661d51a47ede3ea987d37c003191da"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/net.minidev/accessors-smart@2.5.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://urielch.github.io/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/netplex/json-smart-v2"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.ow2.asm/asm@9.6?type=jar",
+      "publisher" : "OW2",
+      "group" : "org.ow2.asm",
+      "name" : "asm",
+      "version" : "9.6",
+      "description" : "ASM, a very small and fast Java bytecode manipulation framework",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6f8bccf756f170d4185bb24c8c2d2020"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "aa205cf0a06dbd8e04ece91c0b37c3f5d567546a"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "01a5ea6f5b43bf094c52a50e18325a60af7bb02e74d24f9bc2c727d43e514578fd968b30ff22f9d2720caec071458f9ff82d11a21fbb1ebc42d8203e737c4b52"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "80e0a92442db343baea7bab9bb1d0b7037c98d6aa54172820b21ea45e51dfea42b7670aa39e938d0f88ad4466004a19a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "98a43a49425054d14574e75aa034e3758b8f0ac382c705773cd80be4065df6b198ba106f443d1d389a8d2a027586f122"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "df966c1a8edf2f5dc378e60468399b60d9d27481241462b75a61033b06f95578"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "5f2cfa6ca6e369f5e94861652da88c12c0554ea4aa0c8472393011aacadeda2309d00d9817417debac5d1c4e01bb9584cb9c438eff63bd10ed89666bb9cffed7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "BSD-3-Clause",
+            "url" : "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.ow2.asm/asm@9.6?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://asm.ow2.io/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://repository.ow2.org/nexus/service/local/staging/deploy/maven2"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://gitlab.ow2.org/asm/asm/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://mail.ow2.org/wws/arc/asm/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://gitlab.ow2.org/asm/asm/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springdoc/springdoc-openapi-starter-webmvc-ui@2.7.0?type=jar",
+      "group" : "org.springdoc",
+      "name" : "springdoc-openapi-starter-webmvc-ui",
+      "version" : "2.7.0",
+      "description" : "Spring openapi documentation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "c358f8f3c8d649e96181e0bcc785a13c"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4426174e7fa7428a1c5f2edbd352c89e3e6b9794"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "7697085f18df08df590097052b706cba21fdad96c2eb8628bc1c02c9d1396f18"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "bbe1eab7bb72da533d5efebbf02287dc1fda142085e3901b55238f7ca90d5e23d4f07ae7ecc2aa6e8846163976af809ff12658359256913871b4911c2e53d877"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c64907f0e3fc4e3866167e69ab72a4e1b4b22f1aa2dfb9a3c7173dc168dfa09a7645e934e0df9d254320099babf18dea"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "e8a1458ec2058ad3fa446b4e5d051e4b68b2cafb6150d5c99aa1b4327c82c5ad45a32ffd1ec0fb2e2a7821b7b1ddff78"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "3d0f1e215a7474d33da9e35624b294b8e92be36d6d775d929d6d41c83de9b6ca"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "d36248bd2520413554d5998bc51758243d049639fa16f429aefcc37b7a9a305281683faf11d42ef184c99e93400416daa342f1317a2a33a7acdb277127e9faa5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springdoc/springdoc-openapi-starter-webmvc-ui@2.7.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://springdoc.org/springdoc-openapi-starter-webmvc-ui/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springdoc/springdoc-openapi-starter-webmvc-api@2.7.0?type=jar",
+      "group" : "org.springdoc",
+      "name" : "springdoc-openapi-starter-webmvc-api",
+      "version" : "2.7.0",
+      "description" : "Spring openapi documentation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8a1542495b9d3c365913b46a1b6935e7"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "37d5234d1fd470918775569ebe240e18c367340f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ad799893a01e15e65ff673d77c0f2adb4c5c66bd6a5ee4f7e74c65582385dec6"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "281b7ea16739a5aa3d00d5a7e5ca3f43a7fa551e71e8c8c82fa39dd584a5fe880918215dd4f0e2461d055f9fc9229d6c366f88b54594b9e36790a23de4b4d655"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c61cf2ab989f8f599c98ef3ca2d81ed8507117fd1c39b649908a1811a82dc210c5b8b6e7f1cbfa6e7b284cecd5b4700d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "25e3d27286ec7809d61a89c3ccfbc96c75e14d016941c2f08244a5d1da91a5bfa8d1b11b1f73c63e397a43328fb344ad"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "c458793cd3598abbed3f7c686645b0cc8727cb905e8da04111201ee5678f8659"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "07d32ab4a5203dcee2bc38efdd298f495b485e21298dde78fe3adf7fc251c3e98691e99058b42872461e28294df678b95b46dc655baf78f99f98fac9acda07b5"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springdoc/springdoc-openapi-starter-webmvc-api@2.7.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://springdoc.org/springdoc-openapi-starter-webmvc-api/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springdoc/springdoc-openapi-starter-common@2.7.0?type=jar",
+      "group" : "org.springdoc",
+      "name" : "springdoc-openapi-starter-common",
+      "version" : "2.7.0",
+      "description" : "Spring openapi documentation",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3b947aed020b389d423676513dbcabbd"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bba119cebeab38aa8ba9a506d76bd611407348c1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "2258ad36f2453b91fb4ee7466732cad9d40716faa793481a365f0e14974fe7a1"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "34ab54689579122f8457b800520ed852e595ec9c943ce716dc8483d1d2d19312767458b3ae75a4d2df2d5f8e3a99d6910ec161aec4e4e11df77911f1add9f4a5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "b635a61ccdbf6b1a0fac5b7f7de7fb227e2e9206fc987006e96103c9065b17dcb4be64b533d758b201436cf1abf35cf0"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "80bf76a39bf17ad344317069ef6723ad3366cd6ec8ad21921b58a6f904b2c5473e161609eb820533dad10f500e93133a"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "92057f07dbbc76c97327b563598ba05c165ba4fc534803d98f92f9ca8de0f6bc"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "549f9b9f04d9d7c60734629d4fd401d91c552ae6ac3c466fffe3f3cacc820e7ea0dc85f9fcb4aeec72bfadf78ace87a61b48360380bbea6d0210e642a741fc1e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.springdoc/springdoc-openapi-starter-common@2.7.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://springdoc.org/springdoc-openapi-starter-common/"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.swagger.core.v3/swagger-core-jakarta@2.2.25?type=jar",
+      "group" : "io.swagger.core.v3",
+      "name" : "swagger-core-jakarta",
+      "version" : "2.2.25",
+      "description" : "swagger-core-jakarta",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "294ca9bb324e6e770b8e90df9c98a8fa"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "83eceb1d4af30f9131b0e0c607b83b2c921c2525"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "28560f86a4ec4092fe807482740b00220ca8ba3d723dfde00119e6dee791f4f7"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "21c55d25b5b07ea35bffedc42922a3654d2b8f0ef67e9df1d4d8cff97bc55878242c99db77c8528af7ed348cff7233145df2ecfea7cde2617f9d1dedb03ee6f6"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "df018f4a54d958e4574a87d4abbb8e1a2f3b56467ded3bd8c74357e7fb85569eb47eed9ddbbfbda0b90e1feab90417e6"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "32e53af653d4e5cd18fdd69f8acf4c938c8a7e8b07d96054b4d781e5df94af0e2256241f29da37b17b234c835e6f9eea"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "245e996f42fe29357773ed1d74b8bd7d174f1d91df1b2a11ec58965576aa5cf0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "ff778e220ec208d79a4c3c9d86cb31db81158ddeaa75041ebee9a9a249b47c1437afc7c248a1437bd6666ae2b383f43b73f7ae8fe549b85f628ed24585390860"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.swagger.core.v3/swagger-core-jakarta@2.2.25?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/swagger-api/swagger-core/modules/swagger-core-jakarta"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/swagger-api/swagger-core/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://groups.google.com/forum/#!forum/swagger-swaggersocket"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/swagger-api/swagger-core/modules/swagger-core-jakarta"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.swagger.core.v3/swagger-annotations-jakarta@2.2.25?type=jar",
+      "group" : "io.swagger.core.v3",
+      "name" : "swagger-annotations-jakarta",
+      "version" : "2.2.25",
+      "description" : "swagger-annotations-jakarta",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "f175dd534038396979aefaa78f52064b"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "6d8682e3c878769b2658397dacbd2474602487dc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "046d4bbc957fb8852474b28711c8be97753935ac4ae49ce39d52da584bb3bd11"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "5913db32dcb8ca2a5a634a668f929ce0ddc54e4db3f5ab8ff0cf29c72b9e3e1113ec67ebd0826a576dabfcb122e8803db9604aaaa75f251fa7071c6cb69fe13b"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "d56f50a16016992c16f0ee07d12d264aeba17aad1a92c11a06065537c8f55c2a964be424e1535dd386624196def06f0b"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "8402b89bdd9adb202db3ba3d0564d0f7a6afb9fb523c49895e3eb8d03a29904564a1807aebf2cc759759f7238f59c579"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "acd81169e7f53799c9c8130d7f65c3e51ea3c3a74770e48877822ed254749bab"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "fe3f1e80cb89b5e629d1c96fbc3f37f21a8b15b786cbd7f364fd00d92c10f3dd2d5025c1cdb41fe29e9da70e242cda9b630e4432a63072f8ce84b02f2c041f42"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.swagger.core.v3/swagger-annotations-jakarta@2.2.25?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/swagger-api/swagger-core/modules/swagger-annotations-jakarta"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/swagger-api/swagger-core/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://groups.google.com/forum/#!forum/swagger-swaggersocket"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/swagger-api/swagger-core/modules/swagger-annotations-jakarta"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/io.swagger.core.v3/swagger-models-jakarta@2.2.25?type=jar",
+      "group" : "io.swagger.core.v3",
+      "name" : "swagger-models-jakarta",
+      "version" : "2.2.25",
+      "description" : "swagger-models-jakarta",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b1d56273d881ad66d4c0d10d2e6fecd6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "abfe0fce84b0d8d8371f52405816a30cdba64493"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4a47e02919dd9c5540458e8a7ab8a6125504d479cdf3e95533d26f1afc76791d"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4a6502cc5c7d24bba3f364fe66e8394d9eb6403e02cb9a5859789050382f1061a27e83cc22af6bc278c12887beb5352194469dc823ddcdab3a5d97e117ce3c59"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "1992c5142ab85720fafc2dde1d8397890dd48d98cc91f082ccc9a0f70d4da1b8c0352c5e6c3b5d0236f9eb42031e763d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "cabb30b5f70a3a437d2311b439523802c31442a047d2b8c3ad4a75d087f0f3a086febb08fbbff74e831029ffa250509b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "18c0b8b32c498d04224a3511954790e0f7ae1b13d0395ef8df3578f492aa6563"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "1e2af502cd81c4a32684dfa88750b6df04f335dba9c2d319432c311efc62d27a40c1507e373b36672704000ee643dad6d24bd707e90c7559b3286f176b3f156d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.swagger.core.v3/swagger-models-jakarta@2.2.25?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/swagger-api/swagger-core/modules/swagger-models-jakarta"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/swagger-api/swagger-core/issues"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://groups.google.com/forum/#!forum/swagger-swaggersocket"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/swagger-api/swagger-core/modules/swagger-models-jakarta"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@3.0.2?type=jar",
+      "publisher" : "Eclipse Foundation",
+      "group" : "jakarta.validation",
+      "name" : "jakarta.validation-api",
+      "version" : "3.0.2",
+      "description" : "Jakarta Bean Validation API",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "3a1ee6efca3e41e3320599790f54c5eb"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "92b6631659ba35ca09e44874d3eb936edfeee532"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "291c25e6910cc6a7ebd96d4c6baebf6d7c37676c5482c2d96146e901b62c1fc9"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "8ff9a450e13dad49ac8268ab8c591e045e5056f9459efa09fbb3561b5c879526b344e2648602bf65d387620064cf0c3a00e1243c6422c85a21b53dbab8749a40"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ab594665f5416edc8b42687e4ca17583fdcf886725ed98a88beb42bb5980d3672a5a5b7dd93b73c2282393ef1814d21d"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "bd43bd51ad4b56fe5bed62d478554a0e2a183b8ce38ed8606adb52d219eefe2efedafdd3d530b1f680824f54a680ab4b"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "48b53a0b142c3b314427ea2133e54151ed8263c1627527b8bc824784596840d7"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "3b6ec58f766f0958be2529b66d12bf492dfb78c49bfd41be87d9102e0885144156a693828f201a2a7019774c02824dfcaf717394a8858779fc9b2cd44b74b453"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/jakarta.validation/jakarta.validation-api@3.0.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://beanvalidation.org"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://hibernate.atlassian.net/projects/BVAL/"
+        },
+        {
+          "type" : "mailing-list",
+          "url" : "https://dev.eclipse.org/mhonarc/lists/jakarta.ee-community/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/eclipse-ee4j/beanvalidation-api"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.webjars/swagger-ui@5.18.2?type=jar",
+      "group" : "org.webjars",
+      "name" : "swagger-ui",
+      "version" : "5.18.2",
+      "description" : "WebJar for Swagger UI",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "124dc927d3740dacb2ee2c23dce93672"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "368118833fc82beedbc17783972c836aa22e0872"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b680a34c34a06949cbe4d99c06d7c6e8f3ac229951a71a62d5ee5a5a6496b060"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "4414673361bcc5fd8c5b4a8e097a4f597dabb5d6fdfa71b97bf6eb5f84e7985832024fda85da81191ab9588b42dfed8c4d1179c410d877208575b7e853aca324"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "4e8a085df421f6b5c187ebdc0798dedd5a4562396edef6a384e58e321e0283c9965cc596f647ed55c51f95ebd1bb7152"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "6ff2710b1ff79bcfb3bb3abd2415047a1e6dc3b0189c3801a9a7a7409b8ee139a25c4a0752b848706306f1eaa5886613"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "bc2be278b11be8c16b36db1e069b42558108757dc380560b75c9b9c349c888a0"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "364932789bf0ea9c44cf29f4f2c9c84f62cf02356ec05f178f99eac7fab7bc78cdb8f75f79b5fbe9d5c690b7fbbf9830d93951909af2c3e7d5b83d72d5a4f9a6"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.webjars/swagger-ui@5.18.2?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.webjars.org"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/swagger-api/swagger-ui/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/swagger-api/swagger-ui"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.webjars/webjars-locator-lite@1.0.1?type=jar",
+      "group" : "org.webjars",
+      "name" : "webjars-locator-lite",
+      "version" : "1.0.1",
+      "description" : "WebJars Locator Lite",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "1016823f8027f1d6ce442b94cce43391"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "b4389136604123d4fe4199cc29b94a33206996bc"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "a216c101379f6654bd65e50bf2c9d8a3575bc7d6e8de2898286ac49c56d9ae99"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "83f7c1d9f5eb2cee73c248ec647a7da69a7ef654067a207f5220dc359d1bf25c340a56d1f6fabd250fa523e2dceb1ed07c02c3f2317f44b9a6b9aa1c96df58e9"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c0c2ba74b1ac660d76f0fa8ba95b7afb8a3888224a9706f5427d4770e4215f72c5c4ef79b52a3ffc8a077a184aca9c3a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "7f110e122dfbde06cc9aa18eb52e6032d9a23cdfd7c413481c0a2e36322b3c158dc2de048a517242595f1146c619aedb"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4fd199a43a6b222b43051d6ab62ecb451a786c3bc26138e3e1c0fc560a5bb392"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "b7415b05b21f3dcae69a49d1ea658fde1b1fe3ef5aebd414d69a74a8ab88a6045c550013553cff8d458866e8d0fb5ba4f6f71aae26cc0df973c20aeb4161e92a"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "https://opensource.org/license/mit/"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.webjars/webjars-locator-lite@1.0.1?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://webjars.org"
+        },
+        {
+          "type" : "build-system",
+          "url" : "https://github.com/webjars/webjars-locator-lite/actions"
+        },
+        {
+          "type" : "distribution-intake",
+          "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/webjars/webjars-locator-lite/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/webjars/webjars-locator-lite"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.jspecify/jspecify@1.0.0?type=jar",
+      "group" : "org.jspecify",
+      "name" : "jspecify",
+      "version" : "1.0.0",
+      "description" : "An artifact of well-named and well-specified annotations to power static analysis checks",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "9133aba420d0ca3b001dbb6ae9992cf6"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7425a601c1c7ec76645a78d22b8c6a627edee507"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "efded31ef5b342f09422935076e599789076431e93a746685c0607e7de5592719ba6aacde0be670b3f064d1e85630d58d5bce6b34aed2a288fdb34f745efb7bc"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "814f860e5a44ead6c457676841eef471a8b87be31b84c60a8a4477a18a9cbcb6e3c2ae700969d5c5e52309d961e0537a"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "c8844e5b71e5ecfbb7366097ce34af2f5863d86d5ccc3f9ec384d8ade4b60ccc8124c7fc88664f1afd2b0962fc8775bf"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "4b4f08ad7606a3ac62997779484919a302267b26d26ee19125f8a7eea60e8a71"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "65c6845ebae981cb81b61107707ced39f5b377dae970b47606ef482aaf10e3729def0da40d9377c43abbfb483a5ceae039b0d51c129c50a6d36ad351a5d6b01e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.jspecify/jspecify@1.0.0?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://jspecify.org/"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/jspecify/jspecify/"
+        }
+      ]
+    }
+  ],
+  "dependencies" : [
+    {
+      "ref" : "pkg:maven/de.starwit/sBOM-generator@0.0.8-SNAPSHOT?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.cyclonedx/cyclonedx-core-java@10.1.0?type=jar",
+        "pkg:maven/com.github.librepdf/openpdf@2.0.3?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-data-rest@3.4.1?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter@3.4.1?type=jar",
+        "pkg:maven/org.apache.httpcomponents.client5/httpclient5@5.4.1?type=jar",
+        "pkg:maven/org.springdoc/springdoc-openapi-starter-webmvc-ui@2.7.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.cyclonedx/cyclonedx-core-java@10.1.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/commons-codec/commons-codec@1.17.1?type=jar",
+        "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+        "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+        "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.18.2?type=jar",
+        "pkg:maven/com.networknt/json-schema-validator@1.5.4?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/commons-codec/commons-codec@1.17.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/commons-io/commons-io@2.18.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.commons/commons-collections4@4.4?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.github.package-url/packageurl-java@1.5.0?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.18.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+        "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.2?type=jar",
+        "pkg:maven/com.fasterxml.woodstox/woodstox-core@7.0.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.woodstox/woodstox-core@7.0.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.codehaus.woodstox/stax2-api@4.2.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.networknt/json-schema-validator@1.5.4?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.ethlo.time/itu@1.10.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.18.2?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.ethlo.time/itu@1.10.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.18.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+        "pkg:maven/org.yaml/snakeyaml@2.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.yaml/snakeyaml@2.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/com.github.librepdf/openpdf@2.0.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-data-rest@3.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter-web@3.4.1?type=jar",
+        "pkg:maven/org.springframework.data/spring-data-rest-webmvc@4.4.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-web@3.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@3.4.1?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-json@3.4.1?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@3.4.1?type=jar",
+        "pkg:maven/org.springframework/spring-web@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-webmvc@6.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter@3.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot@3.4.1?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@3.4.1?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-logging@3.4.1?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@2.1.1?type=jar",
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar",
+        "pkg:maven/org.yaml/snakeyaml@2.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot@3.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-context@6.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-core@6.2.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-jcl@6.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-jcl@6.2.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-context@6.2.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-aop@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-expression@6.2.1?type=jar",
+        "pkg:maven/io.micrometer/micrometer-observation@1.14.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-aop@6.2.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-expression@6.2.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.micrometer/micrometer-observation@1.14.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/io.micrometer/micrometer-commons@1.14.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.micrometer/micrometer-commons@1.14.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@3.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot@3.4.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-logging@3.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/ch.qos.logback/logback-classic@1.5.12?type=jar",
+        "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.24.3?type=jar",
+        "pkg:maven/org.slf4j/jul-to-slf4j@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-classic@1.5.12?type=jar",
+      "dependsOn" : [
+        "pkg:maven/ch.qos.logback/logback-core@1.5.12?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/ch.qos.logback/logback-core@1.5.12?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.24.3?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.logging.log4j/log4j-api@2.24.3?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.logging.log4j/log4j-api@2.24.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.slf4j/jul-to-slf4j@2.0.16?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.annotation/jakarta.annotation-api@2.1.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-json@3.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-starter@3.4.1?type=jar",
+        "pkg:maven/org.springframework/spring-web@6.2.1?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-web@6.2.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar",
+        "pkg:maven/io.micrometer/micrometer-observation@1.14.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.18.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.18.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.18.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@3.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@2.1.1?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.34?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@10.1.34?type=jar",
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@10.1.34?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.34?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@10.1.34?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@10.1.34?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.34?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-webmvc@6.2.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-aop@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-context@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-expression@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-web@6.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.data/spring-data-rest-webmvc@4.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.data/spring-data-rest-core@4.4.1?type=jar",
+        "pkg:maven/org.springframework/spring-webmvc@6.2.1?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.data/spring-data-rest-core@4.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-tx@6.2.1?type=jar",
+        "pkg:maven/org.springframework.hateoas/spring-hateoas@2.4.1?type=jar",
+        "pkg:maven/org.springframework.data/spring-data-commons@3.4.1?type=jar",
+        "pkg:maven/org.springframework.plugin/spring-plugin-core@3.0.0?type=jar",
+        "pkg:maven/org.atteo/evo-inflector@1.3?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.18.2?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework/spring-tx@6.2.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.hateoas/spring-hateoas@2.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-aop@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-context@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-web@6.2.1?type=jar",
+        "pkg:maven/org.springframework.plugin/spring-plugin-core@3.0.0?type=jar",
+        "pkg:maven/com.jayway.jsonpath/json-path@2.9.0?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.plugin/spring-plugin-core@3.0.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-context@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-aop@6.2.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/com.jayway.jsonpath/json-path@2.9.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/net.minidev/json-smart@2.5.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/net.minidev/json-smart@2.5.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/net.minidev/accessors-smart@2.5.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/net.minidev/accessors-smart@2.5.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.ow2.asm/asm@9.6?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.ow2.asm/asm@9.6?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.springframework.data/spring-data-commons@3.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework/spring-core@6.2.1?type=jar",
+        "pkg:maven/org.springframework/spring-beans@6.2.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.atteo/evo-inflector@1.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents.client5/httpclient5@5.4.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.httpcomponents.core5/httpcore5@5.3.1?type=jar",
+        "pkg:maven/org.apache.httpcomponents.core5/httpcore5-h2@5.3.1?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents.core5/httpcore5@5.3.1?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.apache.httpcomponents.core5/httpcore5-h2@5.3.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.httpcomponents.core5/httpcore5@5.3.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springdoc/springdoc-openapi-starter-webmvc-ui@2.7.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springdoc/springdoc-openapi-starter-webmvc-api@2.7.0?type=jar",
+        "pkg:maven/org.webjars/swagger-ui@5.18.2?type=jar",
+        "pkg:maven/org.webjars/webjars-locator-lite@1.0.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springdoc/springdoc-openapi-starter-webmvc-api@2.7.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springdoc/springdoc-openapi-starter-common@2.7.0?type=jar",
+        "pkg:maven/org.springframework/spring-webmvc@6.2.1?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.springdoc/springdoc-openapi-starter-common@2.7.0?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@3.4.1?type=jar",
+        "pkg:maven/io.swagger.core.v3/swagger-core-jakarta@2.2.25?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.swagger.core.v3/swagger-core-jakarta@2.2.25?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.apache.commons/commons-lang3@3.17.0?type=jar",
+        "pkg:maven/org.slf4j/slf4j-api@2.0.16?type=jar",
+        "pkg:maven/io.swagger.core.v3/swagger-annotations-jakarta@2.2.25?type=jar",
+        "pkg:maven/io.swagger.core.v3/swagger-models-jakarta@2.2.25?type=jar",
+        "pkg:maven/org.yaml/snakeyaml@2.3?type=jar",
+        "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@4.0.2?type=jar",
+        "pkg:maven/jakarta.validation/jakarta.validation-api@3.0.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.18.2?type=jar",
+        "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/io.swagger.core.v3/swagger-annotations-jakarta@2.2.25?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/io.swagger.core.v3/swagger-models-jakarta@2.2.25?type=jar",
+      "dependsOn" : [
+        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.18.2?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@4.0.2?type=jar",
+      "dependsOn" : [
+        "pkg:maven/jakarta.activation/jakarta.activation-api@2.1.3?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.activation/jakarta.activation-api@2.1.3?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/jakarta.validation/jakarta.validation-api@3.0.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.webjars/swagger-ui@5.18.2?type=jar",
+      "dependsOn" : [ ]
+    },
+    {
+      "ref" : "pkg:maven/org.webjars/webjars-locator-lite@1.0.1?type=jar",
+      "dependsOn" : [
+        "pkg:maven/org.jspecify/jspecify@1.0.0?type=jar"
+      ]
+    },
+    {
+      "ref" : "pkg:maven/org.jspecify/jspecify@1.0.0?type=jar",
+      "dependsOn" : [ ]
+    }
+  ]
+}


### PR DESCRIPTION
Report generation service offers flag to create compact table without description field.

## Motivation and Context
Compact report version is much shorter.

## How has this been tested?
More unit for sbom parsing added. PDF generation tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
